### PR TITLE
Added Fallback for TALB and Refresh Interval Connection Parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ You can also use `*` for specifying all the zones in a given region as shown bel
 "postgres://username:password@localhost:5433/database_name?loadBalance=true&topologyKeys=cloud1.region1.*:1,cloud1.region2.*:2";
 ```
 
-The driver attempts connection to servers in the first fallback placement(s) if it does not find any servers available in the primary placement(s), then it attempts to connect to servers in the second fallback placement(s), if specified and so on. At last if no servers specified in topologyKeys are available, then it will attempt to connect to any server in the cluster (load balancing will still be followed for the entire cluster).
+The driver attempts to connect to a node in following order: the least loaded node in the 1) primary placement(s), else in the 2) first fallback if specified, else in the 3) second fallback if specified and so on.
+If no nodes are available either in primary placement(s) or in any of the fallback placements, then nodes in the rest of the cluster are attempted.
 And this repeats for each connection request.
 
 ## Specifying Refresh Interval

--- a/README.md
+++ b/README.md
@@ -66,9 +66,11 @@ To specify Refresh Interval, use the parameter `ybServersRefreshInterval` in the
 ```
 "postgres://username:password@localhost:5433/database_name?ybServersRefreshInterval=X&loadBalance=true&topologyKeys=cloud1.region1.*:1,cloud1.region2.*:2";
 ```
+Here, X is the value of the refresh interval (seconds) in integer. 
+
 To know more visit the [docs page](https://docs.yugabyte.com/preview/drivers-orms/).
 
-For a working example which demonstrates the configurations of connection load balancing see the [driver-examples](https://github.com/yugabyte/driver-examples/tree/main/go/pgx) repository.
+For a working example which demonstrates the configurations of connection load balancing see the [driver-examples](https://github.com/yugabyte/driver-examples/tree/main/nodejs) repository.
 
 Non-blocking PostgreSQL client for Node.js. Pure JavaScript and optional native libpq bindings.
 

--- a/packages/pg/lib/client.js
+++ b/packages/pg/lib/client.js
@@ -158,14 +158,14 @@ class Client extends EventEmitter {
       for (let value of hosts) {
         let host = value
         let placementInfoOfHost
-        if(Client.hostServerInfo.has(host)){
+        if (Client.hostServerInfo.has(host)) {
           placementInfoOfHost = Client.hostServerInfo.get(host).placementInfo
-        }else{
+        } else {
           placementInfoOfHost = hostsList.get(host).placementInfo
         }
         var toCheckStar = placementInfoOfHost.split('.')
-        var StarplacementInfoOfHost = toCheckStar[0]+"."+toCheckStar[1]+".*"
-        if (!Client.topologyKeyMap.get(i).includes(placementInfoOfHost) && !Client.topologyKeyMap.get(i).includes(StarplacementInfoOfHost) ) {
+        var starPlacementInfoOfHost = toCheckStar[0]+"."+toCheckStar[1]+".*"
+        if (!Client.topologyKeyMap.get(i).includes(placementInfoOfHost) && !Client.topologyKeyMap.get(i).includes(starPlacementInfoOfHost)) {
           continue
         }
         let hostCount
@@ -215,24 +215,32 @@ class Client extends EventEmitter {
 
   isValidKey(key) {
     var zones = key.split(':')
-    if(zones.length == 0 || zones.length >2){
+    if (zones.length == 0 || zones.length >2) {
       return false
     }
     var keyParts = zones[0].split('.')
     if (keyParts.length !== 3) {
       return false
     }
-    if(zones[1]==undefined){
+    if (zones[1]==undefined) {
       zones[1]='1'
     }
     zones[1]=Number(zones[1])
-    if(zones[1]<1 || zones[1]>10 || isNaN(zones[1]) || !Number.isInteger(zones[1])){
+    if (zones[1]<1 || zones[1]>10 || isNaN(zones[1]) || !Number.isInteger(zones[1])) {
       return false
     }
-    if(keyParts[2]!="*"){
+    if (keyParts[2]!="*") {
       return Client.placementInfoHostMap.has(zones[0])
+    } else {
+      var allPlacementInfo = Client.placementInfoHostMap.keys();
+      for(let placeInfo of allPlacementInfo){
+        var placeInfoParts = placeInfo.split('.')
+        if(keyParts[0]==placeInfoParts[0] && keyParts[1]==placeInfoParts[1]){
+          return true
+        }
+      }
     }
-    return true
+    return false
   }
 
   incrementConnectionCount() {
@@ -483,7 +491,7 @@ class Client extends EventEmitter {
       let key = seperatedKeys[idx]
       if (this.isValidKey(key)) {
         var zones = key.split(':')
-        if(zones[1]==undefined){
+        if (zones[1]==undefined) {
           zones[1]='1'
         }
         zones[1]=parseInt(zones[1])

--- a/packages/pg/lib/client.js
+++ b/packages/pg/lib/client.js
@@ -62,6 +62,7 @@ class Client extends EventEmitter {
     this.host = this.connectionParameters.host
     this.loadBalance = this.connectionParameters.loadBalance
     this.topologyKeys = this.connectionParameters.topologyKeys
+    this.ybServersRefreshInterval = this.connectionParameters.ybServersRefreshInterval
     this.connectionString = config
     // "hiding" the password so it doesn't show up in stack traces
     // or if the client is console.logged
@@ -127,12 +128,8 @@ class Client extends EventEmitter {
   static hostServerInfo = new Map()
   // Boolean to check if public IP needs to be used or not
   static usePublic = false
-  // Set of topology Keys provided in URL
-  static topologyKeySet = new Set()
-  // time to refresh the ServerMetaData
-  static REFRESING_TIME = 300 // secs
-  // Boolean to Refresh ServerMetaData manually (for testing purpose).
-  static doHardRefresh = false
+  // Map of topology Keys provided in URL
+  static topologyKeyMap = new Map()
 
   _errorAllQueries(err) {
     const enqueueError = (query) => {
@@ -156,32 +153,56 @@ class Client extends EventEmitter {
     }
     let minConnectionCount = Number.MAX_VALUE
     let leastLoadedHosts = []
-    let hosts = hostsList.keys()
-    for (let value of hosts) {
-      let host = value
-      if (this.connectionParameters.topologyKeys !== '') {
+    for (var i = 1; i <= Client.topologyKeyMap.size; i++) {
+      let hosts = hostsList.keys()
+      for (let value of hosts) {
+        let host = value
         let placementInfoOfHost
-        if (!this.checkConnectionMapEmpty()) {
+        if(Client.hostServerInfo.has(host)){
           placementInfoOfHost = Client.hostServerInfo.get(host).placementInfo
-        } else {
+        }else{
           placementInfoOfHost = hostsList.get(host).placementInfo
         }
-        if (!Client.topologyKeySet.has(placementInfoOfHost)) {
+        var toCheckStar = placementInfoOfHost.split('.')
+        var StarplacementInfoOfHost = toCheckStar[0]+"."+toCheckStar[1]+".*"
+        if (!Client.topologyKeyMap.get(i).includes(placementInfoOfHost) && !Client.topologyKeyMap.get(i).includes(StarplacementInfoOfHost) ) {
           continue
         }
+        let hostCount
+        if (typeof hostsList.get(host) === 'object') {
+          hostCount = 0
+        } else {
+          hostCount = hostsList.get(host)
+        }
+        if (minConnectionCount > hostCount) {
+          leastLoadedHosts = []
+          minConnectionCount = hostCount
+          leastLoadedHosts.push(host)
+        } else if (minConnectionCount === hostCount) {
+          leastLoadedHosts.push(host)
+        }
       }
-      let hostCount
-      if (typeof hostsList.get(host) === 'object') {
-        hostCount = 0
-      } else {
-        hostCount = hostsList.get(host)
+      if(leastLoadedHosts.length != 0){
+        break
       }
-      if (minConnectionCount > hostCount) {
-        leastLoadedHosts = []
-        minConnectionCount = hostCount
-        leastLoadedHosts.push(host)
-      } else if (minConnectionCount === hostCount) {
-        leastLoadedHosts.push(host)
+    }
+
+    if (leastLoadedHosts.length === 0) {
+      let hosts = hostsList.keys()
+      for (let value of hosts) {
+        let hostCount
+        if (typeof hostsList.get(value) === 'object') {
+          hostCount = 0
+        } else {
+          hostCount = hostsList.get(value)
+        }
+        if (minConnectionCount > hostCount) {
+          leastLoadedHosts = []
+          minConnectionCount = hostCount
+          leastLoadedHosts.push(value)
+        } else if (minConnectionCount === hostCount) {
+          leastLoadedHosts.push(value)
+        }
       }
     }
     if (leastLoadedHosts.length === 0) {
@@ -193,11 +214,25 @@ class Client extends EventEmitter {
   }
 
   isValidKey(key) {
-    var keyParts = key.split('.')
+    var zones = key.split(':')
+    if(zones.length == 0 || zones.length >2){
+      return false
+    }
+    var keyParts = zones[0].split('.')
     if (keyParts.length !== 3) {
       return false
     }
-    return Client.placementInfoHostMap.has(key)
+    if(zones[1]==undefined){
+      zones[1]='1'
+    }
+    zones[1]=Number(zones[1])
+    if(zones[1]<1 || zones[1]>10 || isNaN(zones[1]) || !Number.isInteger(zones[1])){
+      return false
+    }
+    if(keyParts[2]!="*"){
+      return Client.placementInfoHostMap.has(zones[0])
+    }
+    return true
   }
 
   incrementConnectionCount() {
@@ -249,7 +284,7 @@ class Client extends EventEmitter {
       }, this._connectionTimeoutMillis)
     }
     if (this.connectionParameters.loadBalance) {
-      if (!this.checkConnectionMapEmpty() && Client.hostServerInfo.size) {
+      if (Client.connectionMap.size && Client.hostServerInfo.size) {
         this.host = this.getLeastLoadedServer(Client.connectionMap)
         this.port = Client.hostServerInfo.get(this.host).port
       } else if (Client.failedHosts.size) {
@@ -442,12 +477,23 @@ class Client extends EventEmitter {
     })
   }
 
-  createTopologyKeySet() {
+  createTopologyKeyMap() {
     var seperatedKeys = this.connectionParameters.topologyKeys.split(',')
     for (let idx = 0; idx < seperatedKeys.length; idx++) {
       let key = seperatedKeys[idx]
       if (this.isValidKey(key)) {
-        Client.topologyKeySet.add(key)
+        var zones = key.split(':')
+        if(zones[1]==undefined){
+          zones[1]='1'
+        }
+        zones[1]=parseInt(zones[1])
+        if (Client.topologyKeyMap.has(zones[1])) {
+          let currentzones = Client.topologyKeyMap.get(zones[1])
+          currentzones.push(zones[0])
+          Client.topologyKeyMap.set(zones[1],currentzones)
+        } else {
+          Client.topologyKeyMap.set(zones[1],[zones[0]])
+        }
       } else {
         throw new Error('Bad Topology Key found - ' + key)
       }
@@ -459,22 +505,8 @@ class Client extends EventEmitter {
     Client.lastTimeMetaDataFetched = new Date().getTime() / 1000
     this.createConnectionMap(data)
     if (this.connectionParameters.topologyKeys !== '') {
-      this.createTopologyKeySet()
+      this.createTopologyKeyMap()
     }
-  }
-
-  checkConnectionMapEmpty() {
-    if (this.connectionParameters.topologyKeys === '') {
-      return Client.connectionMap.size === 0
-    }
-    let hosts = Client.connectionMap.keys()
-    for (let value of hosts) {
-      let placementInfo = Client.hostServerInfo.get(value).placementInfo
-      if (Client.topologyKeySet.has(placementInfo)) {
-        return false
-      }
-    }
-    return true
   }
 
   nowConnect(callback) {
@@ -489,27 +521,6 @@ class Client extends EventEmitter {
                 Client.hostServerInfo.delete(this.host)
               } else if (Client.failedHosts.has(this.host)) {
                 Client.failedHosts.delete(this.host)
-              }
-              if (this.checkConnectionMapEmpty() && Client.failedHosts.size === 0) {
-                lock.release()
-                // try with url host and mark that connection type as non-loadBalanced
-                this.host = this.urlHost
-                this.connectionParameters.host = this.host
-                this.connectionParameters.loadBalance = false
-                this.connection =
-                  this.config.connection ||
-                  new Connection({
-                    stream: this.config.stream,
-                    ssl: this.connectionParameters.ssl,
-                    keepAlive: this.config.keepAlive || false,
-                    keepAliveInitialDelayMillis: this.config.keepAliveInitialDelayMillis || 0,
-                    encoding: this.connectionParameters.client_encoding || 'utf8',
-                  })
-                this._connecting = false
-                Client.hostServerInfo.clear()
-                Client.connectionMap.clear()
-                this.connect(callback)
-                return
               }
               lock.release()
               this.connect(callback)
@@ -542,26 +553,6 @@ class Client extends EventEmitter {
               Client.hostServerInfo.delete(this.host)
             } else if (Client.failedHosts.has(this.host)) {
               Client.failedHosts.delete(this.host)
-            }
-            if (this.checkConnectionMapEmpty() && Client.failedHosts.size === 0) {
-              lock.release()
-              this.host = this.urlHost
-              this.connectionParameters.host = this.host
-              this.connectionParameters.loadBalance = false
-              this.connection =
-                this.config.connection ||
-                new Connection({
-                  stream: this.config.stream,
-                  ssl: this.connectionParameters.ssl,
-                  keepAlive: this.config.keepAlive || false,
-                  keepAliveInitialDelayMillis: this.config.keepAliveInitialDelayMillis || 0,
-                  encoding: this.connectionParameters.client_encoding || 'utf8',
-                })
-              this._connecting = false
-              Client.hostServerInfo.clear()
-              Client.connectionMap.clear()
-              this.connect(callback)
-              return
             }
             lock.release()
             this.connect(callback)
@@ -605,7 +596,7 @@ class Client extends EventEmitter {
   isRefreshRequired() {
     let currentTime = new Date().getTime() / 1000
     let diff = Math.floor(currentTime - Client.lastTimeMetaDataFetched)
-    return diff >= Client.REFRESING_TIME
+    return diff >= this.connectionParameters.ybServersRefreshInterval
   }
 
   connect(callback) {
@@ -636,7 +627,7 @@ class Client extends EventEmitter {
             return this.nowConnect(callback)
           })
       } else {
-        if (this.isRefreshRequired() || Client.doHardRefresh) {
+        if (this.isRefreshRequired()) {
           this.getServersInfo()
             .then((res) => {
               this.updateMetaData(res.rows)

--- a/packages/pg/lib/connection-parameters.js
+++ b/packages/pg/lib/connection-parameters.js
@@ -95,6 +95,7 @@ class ConnectionParameters {
     }
     this.loadBalance = val('loadBalance', config)
     this.topologyKeys = val('topologyKeys', config)
+    this.ybServersRefreshInterval = val('ybServersRefreshInterval', config)
 
     if (typeof this.loadBalance === 'string') {
       this.loadBalance = this.loadBalance === 'true'
@@ -103,6 +104,13 @@ class ConnectionParameters {
       if (!this.loadBalance) {
         throw new Error(' You need to enable Load Balance feature to use Topology Aware! ')
       }
+    }
+    this.ybServersRefreshInterval = Number(this.ybServersRefreshInterval)
+    if(isNaN(this.ybServersRefreshInterval) || !Number.isInteger(this.ybServersRefreshInterval)){
+      throw new Error(' You need to Enter valid Refresh Interval ')
+    }
+    if(this.ybServersRefreshInterval<0 || this.ybServersRefreshInterval>600){
+      this.ybServersRefreshInterval = 300
     }
     this.client_encoding = val('client_encoding', config)
     this.replication = val('replication', config)
@@ -143,6 +151,7 @@ class ConnectionParameters {
     add(params, this, 'options')
     add(params, this, 'loadBalance')
     add(params, this, 'topologyKeys')
+    add(params, this, 'ybServersRefreshInterval')
 
     var ssl = typeof this.ssl === 'object' ? this.ssl : this.ssl ? { sslmode: this.ssl } : {}
     add(params, ssl, 'sslmode')

--- a/packages/pg/lib/defaults.js
+++ b/packages/pg/lib/defaults.js
@@ -27,6 +27,9 @@ module.exports = {
   // Topology keys
   topologyKeys: '',
 
+  // Refresh Interval
+  ybServersRefreshInterval: 300,
+
   // number of rows to return at a time from a prepared statement's
   // portal. 0 will return all rows at once
   rows: 0,


### PR DESCRIPTION
Added Fallback for Topology Aware Load Balancing and Refresh Interval Parameter.

Changes:

- Added support for fallback options for the topology-aware load balancing.
```
postgresql://yugabyte:yugabyte@127.0.0.1:5433/yugabyte?loadBalance=true&&topologyKeys=cloud1.region1.zone1:1,cloud1.region1.zone3:2&&ybServersRefreshInterval=0"
```

- The preference value (appended after :) is optional. So it is compatible with previous syntax of specifying cloud placements.

- Preference value :1 means primary placement zone(s), value :2 means first fallback, value :3 means second fallback and so on.

- Added a property `ybServersRefreshInterval` to set the refresh interval time in seconds for fetching info from `yb_servers() `function.

- Previously if all servers in topology-keys are down the connection was retried with Non Load Balanced same url but now the connections fallback to the entire cluster if all servers in topology-keys are down.  





