### PR TITLE
Added Failed-host-ttl-seconds support

### DIFF
--- a/packages/pg/lib/client.js
+++ b/packages/pg/lib/client.js
@@ -159,8 +159,7 @@ class Client extends EventEmitter {
     let leastLoadedHosts = []
     for (var i = 1; i <= Client.topologyKeyMap.size; i++) {
       let hosts = hostsList.keys()
-      for (let value of hosts) {
-        let host = value
+      for (let host of hosts) {
         let placementInfoOfHost
         if (Client.hostServerInfo.has(host)) {
           placementInfoOfHost = Client.hostServerInfo.get(host).placementInfo
@@ -486,7 +485,8 @@ class Client extends EventEmitter {
   }
 
   createConnectionMap(data) {
-    let currConnectionMap = Client.connectionMap
+    const currConnectionMap = new Map(Client.connectionMap)
+    Client.connectionMap.clear()
     data.forEach((eachServer) => {
       if(!Client.failedHosts.has(eachServer.host)){
         if(currConnectionMap.has(eachServer.host)){
@@ -606,8 +606,7 @@ class Client extends EventEmitter {
 
   updateConnectionMapAfterRefresh() {
     let hostsInfoList = Client.hostServerInfo.keys()
-    for (let value of hostsInfoList) {
-      let eachHost = value
+    for (let eachHost of hostsInfoList) {
       if (!Client.connectionMap.has(eachHost)) {
         if(!Client.failedHosts.has(eachHost)){
           Client.connectionMap.set(eachHost, 0)
@@ -622,8 +621,7 @@ class Client extends EventEmitter {
       }
     }
     let connectionMapHostList = Client.connectionMap.keys()
-    for (let value of connectionMapHostList) {
-      let eachHost = value
+    for (let eachHost of connectionMapHostList) {
       if (!Client.hostServerInfo.has(eachHost)) {
         Client.connectionMap.delete(eachHost)
       }


### PR DESCRIPTION
**Changes done:**

1. Added support for `Failed-host-ttl-seconds `
2. Fixed a bug related to Control Connection

**Bug Description**
When a node having the controlConnection goes down, a new controlConnection is created to another node, and the `connectionMap` is reset, due to which if there were any exiting connection to other nodes those get removed from `connectionMap` which can cause un-balanced connection creation.