### PR TITLE
Bug fixes

### DIFF
--- a/packages/pg/lib/client.js
+++ b/packages/pg/lib/client.js
@@ -224,10 +224,12 @@ class Client extends EventEmitter {
   isValidKey(key) {
     var zones = key.split(':')
     if (zones.length == 0 || zones.length >2) {
+      logger.warn("Given topology-key " + key + " is invalid")
       return false
     }
     var keyParts = zones[0].split('.')
     if (keyParts.length !== 3) {
+      logger.warn("Given topology-key " + key + " is invalid")
       return false
     }
     if (zones[1]==undefined) {
@@ -235,21 +237,11 @@ class Client extends EventEmitter {
     }
     zones[1]=Number(zones[1])
     if (zones[1]<1 || zones[1]>10 || isNaN(zones[1]) || !Number.isInteger(zones[1])) {
+      logger.warn("Given topology-key " + key + " is invalid")
       return false
     }
-    if (keyParts[2]!="*") {
-      return Client.placementInfoHostMap.has(zones[0])
-    } else {
-      var allPlacementInfo = Client.placementInfoHostMap.keys();
-      for(let placeInfo of allPlacementInfo){
-        var placeInfoParts = placeInfo.split('.')
-        if(keyParts[0]==placeInfoParts[0] && keyParts[1]==placeInfoParts[1]){
-          return true
-        }
-      }
-    }
-    logger.warn("Given topology-key " + key + " is invalid")
-    return false
+    logger.silly("Given topology-key " + key + " is valid")
+    return true
   }
 
   incrementConnectionCount() {

--- a/packages/pg/package.json
+++ b/packages/pg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yugabytedb/pg",
-  "version": "8.7.3-yb-4",
+  "version": "8.7.3-yb-5",
   "description": "Pure JavaScript PostgreSQL client and native libpq bindings with YugabyteDB smart-driver features",
   "keywords": [
     "database",


### PR DESCRIPTION
This PR includes the following changes:

- Clear `placementInfoHostMap` before each refresh.
- Modified validation of topologyKeys as a topologyKey might not be present in `placementInfoHostMap` if no node is present in that cloud placement.
- Catch control connection creation error and try the next node.
- Add node to `failedHosts` list if control connection creation fails on that node.
- Throw error when all nodes in the cluster are down.
- Added few more logs
- ~~Removed code lines which seemed unnecessary ([312-315](https://github.com/yugabyte/node-postgres/pull/6/files#diff-c63141091dba80ae61344624c42b69ce45c2a37db9774250df42093a40ad6613L312), [580-582](https://github.com/yugabyte/node-postgres/pull/6/files#diff-c63141091dba80ae61344624c42b69ce45c2a37db9774250df42093a40ad6613L580) and [616-618](https://github.com/yugabyte/node-postgres/pull/6/files#diff-c63141091dba80ae61344624c42b69ce45c2a37db9774250df42093a40ad6613L616))~~ (As per review)