### PR TITLE
Control Connection Jenkins bug fix

### DIFF
--- a/packages/pg/lib/client.js
+++ b/packages/pg/lib/client.js
@@ -378,10 +378,17 @@ class Client extends EventEmitter {
   }
 
   async iterateHostList(client) {
+    logger.silly([...Client.hostServerInfo])
+    logger.silly([...Client.failedHosts])
     let upHostsList = Client.hostServerInfo.keys()
     let upHost = upHostsList.next()
     let hostIsUp = false
-    while (upHost.value !== undefined && !hostIsUp && !Client.failedHosts.has(upHost.value)) {
+    while (upHost.value !== undefined && !hostIsUp) {
+      if (Client.failedHosts.has(upHost.value)) {
+        logger.silly(upHost.value + " is present in failed host list, trying next host")
+        upHost = upHostsList.next()
+        continue
+      }
       client.host = upHost.value
       client.connectionParameters.host = client.host
       logger.debug("Trying to create control connection to " + client.host)


### PR DESCRIPTION
Jenkins run failure [3522](https://jenkins.dev.yugabyte.com/job/ecosystem-integration-test/3522/)

**Bug Description**
When creating a new control connection, in `iterateHostList` method if the selected node is found to be in Failed Host list, the method simply returns with `Not able to create control connection to any host in the cluster` rather than trying to create control connection to any other node from `hostServerInfo` Map.