### PR TITLE
Added connection and statement timeout for the control connection and bug fix.

### DIFF
--- a/packages/pg/lib/client.js
+++ b/packages/pg/lib/client.js
@@ -355,7 +355,7 @@ class Client extends EventEmitter {
             this._handleErrorEvent(error)
           }
         } else if (!this._connectionError) {
-          if (Client.controlClientHost === this.host) {
+          if (Client.controlClientHost === this.host && Client.controlClient != undefined) {
             logger.silly("Control Connection host might be down, marking control connection as undefined")
             Client.controlClient = undefined
           }

--- a/packages/pg/lib/client.js
+++ b/packages/pg/lib/client.js
@@ -387,9 +387,6 @@ class Client extends EventEmitter {
   async iterateHostList(client) {
     logger.silly([...Client.hostServerInfo])
     logger.silly([...Client.failedHosts])
-    // Just for testing, will revert this
-    const sortedMap = new Map([...Client.hostServerInfo].sort(([keyA], [keyB]) => keyA.localeCompare(keyB)));
-    Client.hostServerInfo = sortedMap
     let upHostsList = Client.hostServerInfo.keys()
     let upHost = upHostsList.next()
     let hostIsUp = false

--- a/packages/pg/lib/client.js
+++ b/packages/pg/lib/client.js
@@ -121,6 +121,8 @@ class Client extends EventEmitter {
   }
   // Control Connection
   static controlClient = undefined
+  // Control Connection host
+  static controlClientHost = ""
   static lastTimeMetaDataFetched = new Date().getTime() / 1000
   // Map of host -> connectionCount
   static connectionMap = new Map()
@@ -353,6 +355,10 @@ class Client extends EventEmitter {
             this._handleErrorEvent(error)
           }
         } else if (!this._connectionError) {
+          if (Client.controlClientHost === this.host) {
+            logger.silly("Control Connection host might be down, marking control connection as undefined")
+            Client.controlClient = undefined
+          }
           this._handleErrorEvent(error)
         }
       }
@@ -373,6 +379,7 @@ class Client extends EventEmitter {
         Client.connectionMap.delete(client.host)
         Client.hostServerInfo.delete(client.host)
       }
+      logger.silly("Control Connection host is down, marking control connection as undefined")
       Client.controlClient = undefined
     })
   }
@@ -380,6 +387,9 @@ class Client extends EventEmitter {
   async iterateHostList(client) {
     logger.silly([...Client.hostServerInfo])
     logger.silly([...Client.failedHosts])
+    // Just for testing, will revert this
+    const sortedMap = new Map([...Client.hostServerInfo].sort(([keyA], [keyB]) => keyA.localeCompare(keyB)));
+    Client.hostServerInfo = sortedMap
     let upHostsList = Client.hostServerInfo.keys()
     let upHost = upHostsList.next()
     let hostIsUp = false
@@ -426,7 +436,10 @@ class Client extends EventEmitter {
   async getConnection() {
     logger.silly("Creating control connection...")
     let currConnectionString = this.connectionString
-    var client = new Client(currConnectionString)
+    var client = new Client({
+      connectionString: currConnectionString,
+      connectionTimeoutMillis: 10000,
+    });
     this.attachErrorListenerOnClientConnection(client)
     let lookup = util.promisify(dns.lookup)
     let addresses = [{ address: client.host }]
@@ -468,6 +481,7 @@ class Client extends EventEmitter {
         }
       })
     }
+    Client.controlClientHost = client.host
     logger.debug("Created control connection to host " + client.host)
     return client
   }
@@ -477,7 +491,10 @@ class Client extends EventEmitter {
     var client = Client.controlClient
     var result
     await client
-      .query(YB_SERVERS_QUERY)
+      .query({
+        text: YB_SERVERS_QUERY,
+        statement_timeout: 10000, // Timeout after 10 seconds
+      })
       .then((res) => {
         result = res
       })


### PR DESCRIPTION
JIRA: [DB-14206](https://yugabyte.atlassian.net/browse/DB-14206)

This PR implements the following changes:

- add 10 second `connectionTimeoutMillis` and `statement_timeout` for the control connection.
- When a client connection goes bad, mark the control connection as undefined if the host of the connection matches with the control connection host.

Debug pipeline run:

- PG15: [#272](https://jenkins.dev.yugabyte.com/job/users/job/ecosystem-integration-debug/272/)
- PG14: [#273](https://jenkins.dev.yugabyte.com/job/users/job/ecosystem-integration-debug/273/)