### PR TITLE
`connectionString` could be of type `object`

### DIFF
--- a/packages/pg/lib/client.js
+++ b/packages/pg/lib/client.js
@@ -433,10 +433,16 @@ class Client extends EventEmitter {
   async getConnection() {
     logger.silly("Creating control connection...")
     let currConnectionString = this.connectionString
-    var client = new Client({
-      connectionString: currConnectionString,
-      connectionTimeoutMillis: 10000,
-    });
+    let client;
+    if (typeof currConnectionString !== "string") {
+      currConnectionString.connectionTimeoutMillis = 10000
+      client = new Client(currConnectionString)
+    } else {
+      client = new Client({
+          connectionString: currConnectionString,
+          connectionTimeoutMillis: 10000,
+      });
+    }
     this.attachErrorListenerOnClientConnection(client)
     let lookup = util.promisify(dns.lookup)
     let addresses = [{ address: client.host }]

--- a/packages/pg/package.json
+++ b/packages/pg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yugabytedb/pg",
-  "version": "8.7.3-yb-7",
+  "version": "8.7.3-yb-8",
   "description": "Pure JavaScript PostgreSQL client and native libpq bindings with YugabyteDB smart-driver features",
   "keywords": [
     "database",


### PR DESCRIPTION
Applications can provide the connection string in the following 2 formats:

1. String

```
const client = new Client({
  connectionString: 'postgres://username:password@localhost:5432/mydatabase'
});
```

2. Object

```
const client = new Client({
  host: 'localhost',
  port: 5432,
  user: 'username',
  password: 'password',
  database: 'mydatabase'
});
```

When the connection string is of type object, the driver is not able to create the control connection and we see the following log in the output:
`Not able to create control connection to any node due to error str.charAt is not a function`

This is because for the control connection, we are setting the connectionString expecting it to be String.
This PR implements the fix for this.

Debug pipeline run:

- PG15: [#282](https://jenkins.dev.yugabyte.com/job/users/job/ecosystem-integration-debug/282/)
- PG14: [#283](https://jenkins.dev.yugabyte.com/job/users/job/ecosystem-integration-debug/283/)