### PR TITLE
Node type aware load balancing

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ Users can use this feature in two configurations.
 
 In the cluster-aware connection load balancing, connections are distributed across all the tservers in the cluster, irrespective of their placements.
 
-To enable the cluster-aware connection load balancing, provide the parameter `loadBalance` set to true as `loadBalance=true` in the connection url or the connection string (DSN style).
+To enable the cluster-aware connection load balancing, provide the parameter `loadBalance` set to true or any as `loadBalance=any` in the connection url or the connection string (DSN style). [This section](#read-replica-cluster) explains the different values for `load_balance` parameter.
 
 ```
-"postgresql://username:password@localhost:5433/database_name?loadBalance=true"
+"postgresql://username:password@localhost:5433/database_name?loadBalance=any"
 ```
 
 With this parameter specified in the url, the driver will fetch and maintain the list of tservers from the given endpoint (`localhost` in above example) available in the YugabyteDB cluster and distribute the connections equally across them.
@@ -32,7 +32,7 @@ With topology-aware connnection load balancing, users can target tservers in spe
 
 The connections will be distributed equally with the tservers in these zones.
 
-Note that, you would still need to specify `loadBalance=true` to enable the topology-aware connection load balancing.
+Note that, you would still need to specify `loadBalance` to one of the 5 allowed values to enable the topology-aware connection load balancing.
 
 ```
 "postgresql://username:password@localhost:5433/database_name?loadBalance=true&topologyKeys=cloud1.region1.zone1,cloud1.region1.zone2"
@@ -67,6 +67,30 @@ To specify Refresh Interval, use the parameter `ybServersRefreshInterval` in the
 "postgres://username:password@localhost:5433/database_name?ybServersRefreshInterval=X&loadBalance=true&topologyKeys=cloud1.region1.*:1,cloud1.region2.*:2";
 ```
 Here, X is the value of the refresh interval (seconds) in integer. 
+
+## Other Connection Parameters:
+
+### fallback_to_topology_keys_only
+
+Applicable only for TopologyAware Load Balancing. When set to true, the smart driver does not attempt to connect to servers outside of primary and fallback placements specified via property. The default behaviour is to fallback to any available server in the entire cluster.(default value: false)
+
+### failed_host_reconnect_delay_secs
+
+The driver marks a server as failed with a timestamp, when it cannot connect to it. Later, whenever it refreshes the server list via yb_servers(), if it sees the failed server in the response, it marks the server as UP only if failed-host-reconnect-delay-secs time has elapsed. (The yb_servers() function does not remove a failed server immediately from its result and retains it for a while.)(default value: 5 seconds)
+
+## Read Replica Cluster
+
+node-postgres smart driver also enables load balancing across nodes in primary clusters which have associated Read Replica cluster.
+
+The connection property `loadBalance` allows five values using which users can distribute connections among different combination of nodes as per their requirements:
+
+- `only-rr` - Create connections only on Read Replica nodes
+- `only-primary` - Create connections only on primary cluster nodes
+- `prefer-rr` - Create connections on Read Replica nodes. If none available, on any node in the cluster including primary cluster nodes
+- `prefer-primary` - Create connections on primary cluster nodes. If none available, on any node in the cluster including Read Replica nodes
+- `any` or `true` - Equivalent to value true. Create connections on any node in the primary or Read Replica cluster
+
+default value is false
 
 To know more visit the [docs page](https://docs.yugabyte.com/preview/drivers-orms/).
 

--- a/packages/pg/lib/client.js
+++ b/packages/pg/lib/client.js
@@ -139,7 +139,7 @@ class Client extends EventEmitter {
   static hostServerInfoRR = new Map()
   // Boolean to check if public IP needs to be used or not
   static usePublic = false
-  // Map of topology Keys provided in URL
+  // Map of preference value as key and the list of placements as its value
   static topologyKeyMap = new Map()
 
   _errorAllQueries(err) {
@@ -163,7 +163,7 @@ class Client extends EventEmitter {
     if (hostsList.size === 0) {
       return this.host
     }
-    
+
     let hostServerInfo;
 
     if (this.connectionParameters.loadBalance === 'any' || this.connectionParameters.loadBalance === 'true') {
@@ -186,7 +186,7 @@ class Client extends EventEmitter {
           continue
         }
         var toCheckStar = placementInfoOfHost.split('.')
-        var starPlacementInfoOfHost = toCheckStar[0]+"."+toCheckStar[1]+".*"
+        var starPlacementInfoOfHost = toCheckStar[0] + "." + toCheckStar[1] + ".*"
         if (!Client.topologyKeyMap.get(i).includes(placementInfoOfHost) && !Client.topologyKeyMap.get(i).includes(starPlacementInfoOfHost)) {
           continue
         }
@@ -204,7 +204,7 @@ class Client extends EventEmitter {
           leastLoadedHosts.push(host)
         }
       }
-      if(leastLoadedHosts.length != 0){
+      if (leastLoadedHosts.length != 0) {
         break
       }
     }
@@ -217,7 +217,7 @@ class Client extends EventEmitter {
       } else {
         leastLoadedHosts = this.getHosts(hostsList, hostServerInfo)
         if (leastLoadedHosts.length === 0) {
-          if (this.connectionParameters.loadBalance === 'prefer-primary'){
+          if (this.connectionParameters.loadBalance === 'prefer-primary') {
             leastLoadedHosts = this.getHosts(hostsList, new Map(Client.hostServerInfoRR))
           } else {
             leastLoadedHosts = this.getHosts(hostsList, new Map(Client.hostServerInfoPrimary))
@@ -264,7 +264,7 @@ class Client extends EventEmitter {
 
   isValidKey(key) {
     var zones = key.split(':')
-    if (zones.length == 0 || zones.length >2) {
+    if (zones.length == 0 || zones.length > 2) {
       logger.warn("Given topology-key " + key + " is invalid")
       return false
     }
@@ -273,11 +273,11 @@ class Client extends EventEmitter {
       logger.warn("Given topology-key " + key + " is invalid")
       return false
     }
-    if (zones[1]==undefined) {
-      zones[1]='1'
+    if (zones[1] == undefined) {
+      zones[1] = '1'
     }
-    zones[1]=Number(zones[1])
-    if (zones[1]<1 || zones[1]>10 || isNaN(zones[1]) || !Number.isInteger(zones[1])) {
+    zones[1] = Number(zones[1])
+    if (zones[1] < 1 || zones[1] > 10 || isNaN(zones[1]) || !Number.isInteger(zones[1])) {
       logger.warn("Given topology-key " + key + " is invalid")
       return false
     }
@@ -298,7 +298,7 @@ class Client extends EventEmitter {
       let serverInfo = Client.failedHosts.get(host)
       if (serverInfo.node_type === 'primary') {
         Client.hostServerInfoPrimary.set(host, serverInfo)
-      } else if (serverInfo.node_type === 'read_replica'){
+      } else if (serverInfo.node_type === 'read_replica') {
         Client.hostServerInfoRR.set(host, serverInfo)
       }
       Client.failedHosts.delete(host)
@@ -346,13 +346,12 @@ class Client extends EventEmitter {
         this.host = this.getLeastLoadedServer(Client.connectionMap)
         if (Client.hostServerInfoPrimary.has(this.host)) {
           this.port = Client.hostServerInfoPrimary.get(this.host).port
-        } else if (Client.hostServerInfoRR.has(this.host)){
+        } else if (Client.hostServerInfoRR.has(this.host)) {
           this.port = Client.hostServerInfoRR.get(this.host).port
-        } else {
-          this.port = 5433
         }
         logger.silly("Least loaded host received " + this.host + " port " + this.port)
       } else if (Client.failedHosts.size) {
+        //ToDo: Why call getLeastLoadedServer with the failedHosts Map? Is this still required?
         this.host = this.getLeastLoadedServer(Client.failedHosts)
         this.port = Client.failedHosts.get(this.host).port
         logger.silly("Least loaded host from failed host list received " + this.host + " port " + this.port)
@@ -476,18 +475,18 @@ class Client extends EventEmitter {
               keepAliveInitialDelayMillis: client.config.keepAliveInitialDelayMillis || 0,
               encoding: client.connectionParameters.client_encoding || 'utf8',
             })
-            logger.debug("Not able to create control connection to host " + client.host + " adding it to failedHosts")
-            Client.failedHosts.set(client.host, Client.hostServerInfo.get(client.host))
-            let start = new Date().getTime();
-            Client.failedHostsTime.set(client.host, start)
-            Client.connectionMap.delete(client.host)
-            Client.hostServerInfoPrimary.delete(client.host)
-            Client.hostServerInfoRR.delete(client.host)
+          logger.debug("Not able to create control connection to host " + client.host + " adding it to failedHosts")
+          Client.failedHosts.set(client.host, Client.hostServerInfo.get(client.host))
+          let start = new Date().getTime();
+          Client.failedHostsTime.set(client.host, start)
+          Client.connectionMap.delete(client.host)
+          Client.hostServerInfoPrimary.delete(client.host)
+          Client.hostServerInfoRR.delete(client.host)
           client._connecting = false
           upHost = upHostsList.next()
         })
     }
-    if(!hostIsUp) {
+    if (!hostIsUp) {
       logger.debug("Not able to create control connection to any host in the cluster")
       throw new Error('Not able to create control connection to any host in the cluster')
     }
@@ -502,8 +501,8 @@ class Client extends EventEmitter {
       client = new Client(currConnectionString)
     } else {
       client = new Client({
-          connectionString: currConnectionString,
-          connectionTimeoutMillis: 10000,
+        connectionString: currConnectionString,
+        connectionTimeoutMillis: 10000,
       });
     }
     this.attachErrorListenerOnClientConnection(client)
@@ -606,8 +605,8 @@ class Client extends EventEmitter {
     const currConnectionMap = new Map(Client.connectionMap)
     Client.connectionMap.clear()
     data.forEach((eachServer) => {
-      if(!Client.failedHosts.has(eachServer.host)){
-        if(currConnectionMap.has(eachServer.host)){
+      if (!Client.failedHosts.has(eachServer.host)) {
+        if (currConnectionMap.has(eachServer.host)) {
           Client.connectionMap.set(eachServer.host, currConnectionMap.get(eachServer.host))
         } else {
           Client.connectionMap.set(eachServer.host, 0)
@@ -632,16 +631,16 @@ class Client extends EventEmitter {
       let key = seperatedKeys[idx]
       if (this.isValidKey(key)) {
         var zones = key.split(':')
-        if (zones[1]==undefined) {
-          zones[1]='1'
+        if (zones[1] == undefined) {
+          zones[1] = '1'
         }
-        zones[1]=parseInt(zones[1])
+        zones[1] = parseInt(zones[1])
         if (Client.topologyKeyMap.has(zones[1])) {
           let currentzones = Client.topologyKeyMap.get(zones[1])
           currentzones.push(zones[0])
-          Client.topologyKeyMap.set(zones[1],currentzones)
+          Client.topologyKeyMap.set(zones[1], currentzones)
         } else {
-          Client.topologyKeyMap.set(zones[1],[zones[0]])
+          Client.topologyKeyMap.set(zones[1], [zones[0]])
         }
       } else {
         throw new Error('Bad Topology Key found - ' + key)
@@ -728,6 +727,7 @@ class Client extends EventEmitter {
               Client.connectionMap.delete(this.host)
               Client.hostServerInfoRR.delete(this.host)
             } else if (Client.failedHosts.has(this.host)) {
+              //ToDo: Why remove the host from failedHosts? Is this still required?
               logger.silly("Removing host " + this.host + " from failed host list")
               Client.failedHosts.delete(this.host)
               Client.failedHostsTime.delete(this.host)
@@ -753,7 +753,7 @@ class Client extends EventEmitter {
     let hostsInfoList = [...Client.hostServerInfoPrimary.keys(), ...Client.hostServerInfoRR.keys()]
     for (let eachHost of hostsInfoList) {
       if (!Client.connectionMap.has(eachHost)) {
-        if(!Client.failedHosts.has(eachHost)){
+        if (!Client.failedHosts.has(eachHost)) {
           Client.connectionMap.set(eachHost, 0)
         } else {
           let start = new Date().getTime();
@@ -800,6 +800,10 @@ class Client extends EventEmitter {
       logger.silly("Loadbalance is false, falling to upstream behaviour")
       return this.nowConnect(callback)
     }
+    /* 
+    ToDo: We are holding the lock until the user connection gets created. 
+    This looks like an overkill, why is this required?
+    */
     lock.acquire().then(() => {
       logger.silly("loadBalance: " + this.connectionParameters.loadBalance)
       logger.silly("topologyKeys: " + this.connectionParameters.topologyKeys)

--- a/packages/pg/lib/client.js
+++ b/packages/pg/lib/client.js
@@ -842,6 +842,9 @@ class Client extends EventEmitter {
           this.getServersInfo()
             .then((res) => {
               this.updateMetaData(res.rows)
+              if (this.connectionParameters.topologyKeys !== '') {
+                this.createTopologyKeyMap()
+              }
               return this.nowConnect(callback)
             })
             .catch((err) => {

--- a/packages/pg/lib/client.js
+++ b/packages/pg/lib/client.js
@@ -633,7 +633,8 @@ class Client extends EventEmitter {
         }
       } else {
         let start = new Date().getTime();
-        if (start - Client.failedHostsTime.get(eachServer.host) > (DEFAULT_FAILED_HOST_TTL_SECONDS * 1000)) {
+        logger.silly("failedHostReconnectDelaySecs is set to: " + this.connectionParameters.failedHostReconnectDelaySecs)
+        if (start - Client.failedHostsTime.get(eachServer.host) > (this.connectionParameters.failedHostReconnectDelaySecs * 1000)) {
           logger.debug("Removing " + eachServer.host + " from failed host list")
           Client.connectionMap.set(eachServer.host, 0)
           Client.failedHosts.delete(eachServer.host)

--- a/packages/pg/lib/client.js
+++ b/packages/pg/lib/client.js
@@ -826,6 +826,9 @@ class Client extends EventEmitter {
                 } catch (err) {
                   if (err.message.includes('Bad Topology Key found')) {
                     throw err
+                  } else {
+                    //ToDo: Why not throw the error?
+                    logger.debug("Error caught: " + err.message)
                   }
                 }
               })

--- a/packages/pg/lib/client.js
+++ b/packages/pg/lib/client.js
@@ -17,11 +17,12 @@ const YB_SERVERS_QUERY = 'SELECT * FROM yb_servers()'
 const DEFAULT_FAILED_HOST_TTL_SECONDS = 5
 
 class ServerInfo {
-  constructor(hostName, port, placementInfo, public_ip) {
+  constructor(hostName, port, placementInfo, public_ip, node_type) {
     this.hostName = hostName
     this.port = port
     this.placementInfo = placementInfo
     this.public_ip = public_ip
+    this.node_type = node_type
   }
 }
 
@@ -130,10 +131,14 @@ class Client extends EventEmitter {
   static failedHosts = new Map()
   // Map of failedHost -> Time at which host was added to failedHosts Map
   static failedHostsTime = new Map()
-  // Map of placementInfoOfHost -> list of Hosts
-  static placementInfoHostMap = new Map()
-  // Map of Host -> ServerInfo
-  static hostServerInfo = new Map()
+  // Map of placementInfoOfHost -> list of Primary Hosts
+  static placementInfoHostMapPrimary = new Map()
+  // Map of placementInfoOfHost -> list of RR Hosts
+  static placementInfoHostMapRR = new Map()
+  // Map of Primary Host -> ServerInfo
+  static hostServerInfoPrimary = new Map()
+  // Map of RR Host -> ServerInfo
+  static hostServerInfoRR = new Map()
   // Boolean to check if public IP needs to be used or not
   static usePublic = false
   // Map of topology Keys provided in URL
@@ -160,16 +165,27 @@ class Client extends EventEmitter {
     if (hostsList.size === 0) {
       return this.host
     }
+    
+    let hostServerInfo;
+
+    if (this.connectionParameters.loadBalance === 'any' || this.connectionParameters.loadBalance === 'true') {
+      hostServerInfo = new Map([...Client.hostServerInfoPrimary, ...Client.hostServerInfoRR]);
+    } else if (this.connectionParameters.loadBalance === 'only-primary' || this.connectionParameters.loadBalance === 'prefer-primary') {
+      hostServerInfo = new Map(Client.hostServerInfoPrimary);
+    } else {
+      hostServerInfo = new Map(Client.hostServerInfoRR);
+    }
+
     let minConnectionCount = Number.MAX_VALUE
     let leastLoadedHosts = []
     for (var i = 1; i <= Client.topologyKeyMap.size; i++) {
       let hosts = hostsList.keys()
       for (let host of hosts) {
         let placementInfoOfHost
-        if (Client.hostServerInfo.has(host)) {
-          placementInfoOfHost = Client.hostServerInfo.get(host).placementInfo
+        if (hostServerInfo.has(host)) {
+          placementInfoOfHost = hostServerInfo.get(host).placementInfo
         } else {
-          placementInfoOfHost = hostsList.get(host).placementInfo
+          continue
         }
         var toCheckStar = placementInfoOfHost.split('.')
         var starPlacementInfoOfHost = toCheckStar[0]+"."+toCheckStar[1]+".*"
@@ -198,6 +214,9 @@ class Client extends EventEmitter {
     if (leastLoadedHosts.length === 0) {
       let hosts = hostsList.keys()
       for (let value of hosts) {
+        if (!hostServerInfo.has(value)) {
+          continue
+        }
         let hostCount
         if (typeof hostsList.get(value) === 'object') {
           hostCount = 0
@@ -213,6 +232,56 @@ class Client extends EventEmitter {
         }
       }
     }
+    if (leastLoadedHosts.length === 0) {
+      if (this.connectionParameters.loadBalance != 'prefer-primary' || this.connectionParameters.loadBalance != 'prefer-rr') {
+        return this.host
+      } else {
+        if (this.connectionParameters.loadBalance === 'prefer-primary'){
+          hostServerInfo = new Map(Client.hostServerInfoRR);
+          let hosts = hostsList.keys()
+          for (let value of hosts) {
+            if (!hostServerInfo.has(value)) {
+              continue
+            }
+            let hostCount
+            if (typeof hostsList.get(value) === 'object') {
+              hostCount = 0
+            } else {
+              hostCount = hostsList.get(value)
+            }
+            if (minConnectionCount > hostCount) {
+              leastLoadedHosts = []
+              minConnectionCount = hostCount
+              leastLoadedHosts.push(value)
+            } else if (minConnectionCount === hostCount) {
+              leastLoadedHosts.push(value)
+            }
+          }
+        } else {
+          hostServerInfo = new Map(Client.hostServerInfoPrimary);
+          let hosts = hostsList.keys()
+          for (let value of hosts) {
+            if (!hostServerInfo.has(value)) {
+              continue
+            }
+            let hostCount
+            if (typeof hostsList.get(value) === 'object') {
+              hostCount = 0
+            } else {
+              hostCount = hostsList.get(value)
+            }
+            if (minConnectionCount > hostCount) {
+              leastLoadedHosts = []
+              minConnectionCount = hostCount
+              leastLoadedHosts.push(value)
+            } else if (minConnectionCount === hostCount) {
+              leastLoadedHosts.push(value)
+            }
+          }
+        }
+      }
+    }
+
     if (leastLoadedHosts.length === 0) {
       return this.host
     }
@@ -257,7 +326,11 @@ class Client extends EventEmitter {
     } else if (Client.failedHosts.has(host)) {
       logger.debug("Removing " + host + " from failed host list")
       let serverInfo = Client.failedHosts.get(host)
-      Client.hostServerInfo.set(host, serverInfo)
+      if (serverInfo.node_type === 'primary') {
+        Client.hostServerInfoPrimary.set(host, serverInfo)
+      } else if (serverInfo.node_type === 'read_replica'){
+        Client.hostServerInfoRR.set(host, serverInfo)
+      }
       Client.failedHosts.delete(host)
       Client.failedHostsTime.delete(host)
     }
@@ -299,9 +372,15 @@ class Client extends EventEmitter {
       }, this._connectionTimeoutMillis)
     }
     if (this.connectionParameters.loadBalance) {
-      if (Client.connectionMap.size && Client.hostServerInfo.size) {
+      if (Client.connectionMap.size && (Client.hostServerInfoPrimary.size || Client.hostServerInfoRR.size)) {
         this.host = this.getLeastLoadedServer(Client.connectionMap)
-        this.port = Client.hostServerInfo.get(this.host).port
+        if (Client.hostServerInfoPrimary.has(this.host)) {
+          this.port = Client.hostServerInfoPrimary.get(this.host).port
+        } else if (Client.hostServerInfoRR.has(this.host)){
+          this.port = Client.hostServerInfoRR.get(this.host).port
+        } else {
+          this.port = 5433
+        }
         logger.silly("Least loaded host received " + this.host + " port " + this.port)
       } else if (Client.failedHosts.size) {
         this.host = this.getLeastLoadedServer(Client.failedHosts)
@@ -311,7 +390,12 @@ class Client extends EventEmitter {
     }
     if (Client.usePublic) {
       let currentHost = this.host
-      let serverInfo = Client.hostServerInfo.get(currentHost)
+      let serverInfo
+      if (Client.hostServerInfoPrimary.has(this.host)) {
+        serverInfo = Client.hostServerInfoPrimary.get(currentHost)
+      } else if (Client.hostServerInfoRR.has(this.host)) {
+        serverInfo = Client.hostServerInfoRR.get(currentHost)
+      }
       this.prevHostIfUsePublic = currentHost
       this.host = serverInfo.public_ip
       logger.silly("Using public ips, host " + this.host)
@@ -356,6 +440,7 @@ class Client extends EventEmitter {
           }
         } else if (!this._connectionError) {
           if (Client.controlClientHost === this.host && Client.controlClient != undefined) {
+            console.log("Control Connection host might be down, marking control connection as undefined")
             logger.silly("Control Connection host might be down, marking control connection as undefined")
             Client.controlClient = undefined
           }
@@ -371,13 +456,20 @@ class Client extends EventEmitter {
 
   attachErrorListenerOnClientConnection(client) {
     client.on('error', () => {
-      if (Client.hostServerInfo.has(client.host)) {
+      if (Client.hostServerInfoPrimary.has(client.host)) {
         logger.debug("Not able to connect to host " + client.host + " adding it to failedHosts")
-        Client.failedHosts.set(client.host, Client.hostServerInfo.get(client.host))
+        Client.failedHosts.set(client.host, Client.hostServerInfoPrimary.get(client.host))
         let start = new Date().getTime();
         Client.failedHostsTime.set(client.host, start)
         Client.connectionMap.delete(client.host)
-        Client.hostServerInfo.delete(client.host)
+        Client.hostServerInfoPrimary.delete(client.host)
+      } else if (Client.hostServerInfoRR.has(client.host)) {
+        logger.debug("Not able to connect to host " + client.host + " adding it to failedHosts")
+        Client.failedHosts.set(client.host, Client.hostServerInfoRR.get(client.host))
+        let start = new Date().getTime();
+        Client.failedHostsTime.set(client.host, start)
+        Client.connectionMap.delete(client.host)
+        Client.hostServerInfoRR.delete(client.host)
       }
       logger.silly("Control Connection host is down, marking control connection as undefined")
       Client.controlClient = undefined
@@ -385,9 +477,7 @@ class Client extends EventEmitter {
   }
 
   async iterateHostList(client) {
-    logger.silly([...Client.hostServerInfo])
-    logger.silly([...Client.failedHosts])
-    let upHostsList = Client.hostServerInfo.keys()
+    let upHostsList = [...Client.hostServerInfoPrimary.keys(), ...Client.hostServerInfoRR.keys()][Symbol.iterator]()
     let upHost = upHostsList.next()
     let hostIsUp = false
     while (upHost.value !== undefined && !hostIsUp) {
@@ -419,7 +509,8 @@ class Client extends EventEmitter {
             let start = new Date().getTime();
             Client.failedHostsTime.set(client.host, start)
             Client.connectionMap.delete(client.host)
-            Client.hostServerInfo.delete(client.host)
+            Client.hostServerInfoPrimary.delete(client.host)
+            Client.hostServerInfoRR.delete(client.host)
           client._connecting = false
           upHost = upHostsList.next()
         })
@@ -516,25 +607,44 @@ class Client extends EventEmitter {
 
   createServersList(data) {
     logger.silly("Creating servers list")
-    Client.hostServerInfo.clear()
-    Client.placementInfoHostMap.clear()
+    Client.hostServerInfoPrimary.clear()
+    Client.placementInfoHostMapPrimary.clear()
+    Client.hostServerInfoRR.clear()
+    Client.placementInfoHostMapRR.clear()
     data.forEach((eachServer) => {
       var placementInfo = eachServer.cloud + '.' + eachServer.region + '.' + eachServer.zone
-      var server = new ServerInfo(eachServer.host, eachServer.port, placementInfo, eachServer.public_ip)
-      if (Client.placementInfoHostMap.has(placementInfo)) {
-        let currentHosts = Client.placementInfoHostMap.get(placementInfo)
-        currentHosts.push(eachServer.host)
-        Client.placementInfoHostMap.set(placementInfo, currentHosts)
+      var nodeType = eachServer.node_type
+      var server = new ServerInfo(eachServer.host, eachServer.port, placementInfo, eachServer.public_ip, eachServer.node_type)
+      if (nodeType === 'primary') {
+        if (Client.placementInfoHostMapPrimary.has(placementInfo)) {
+          let currentHosts = Client.placementInfoHostMapPrimary.get(placementInfo)
+          currentHosts.push(eachServer.host)
+          Client.placementInfoHostMapPrimary.set(placementInfo, currentHosts)
+        } else {
+          Client.placementInfoHostMapPrimary.set(placementInfo, [eachServer.host])
+        }
+        Client.hostServerInfoPrimary.set(eachServer.host, server)
+        if (eachServer.public_ip === this.host) {
+          Client.usePublic = true
+        }
       } else {
-        Client.placementInfoHostMap.set(placementInfo, [eachServer.host])
-      }
-      Client.hostServerInfo.set(eachServer.host, server)
-      if (eachServer.public_ip === this.host) {
-        Client.usePublic = true
+        if (Client.placementInfoHostMapRR.has(placementInfo)) {
+          let currentHosts = Client.placementInfoHostMapRR.get(placementInfo)
+          currentHosts.push(eachServer.host)
+          Client.placementInfoHostMapRR.set(placementInfo, currentHosts)
+        } else {
+          Client.placementInfoHostMapRR.set(placementInfo, [eachServer.host])
+        }
+        Client.hostServerInfoRR.set(eachServer.host, server)
+        if (eachServer.public_ip === this.host) {
+          Client.usePublic = true
+        }
       }
     })
-    logger.debug("Updated placementInfoHost Map " + [...Client.placementInfoHostMap])
-    logger.debug("Updated hostServerInfo to " + [...Client.hostServerInfo] + " and usePublic to " + Client.usePublic)
+    logger.debug("Updated placementInfoHostPrimary Map " + [...Client.placementInfoHostMapPrimary])
+    logger.debug("Updated hostServerInfoPrimary to " + [...Client.hostServerInfoPrimary] + " and usePublic to " + Client.usePublic)
+    logger.debug("Updated placementInfoHostRR Map " + [...Client.placementInfoHostMapRR])
+    logger.debug("Updated hostServerInfoRR to " + [...Client.hostServerInfoRR] + " and usePublic to " + Client.usePublic)
   }
 
   createConnectionMap(data) {
@@ -604,13 +714,20 @@ class Client extends EventEmitter {
         this._connect((error) => {
           if (error) {
             if (this.connectionParameters.loadBalance) {
-              if (Client.hostServerInfo.has(this.host)) {
+              if (Client.hostServerInfoPrimary.has(this.host)) {
                 logger.debug("Adding " + this.host + " to failed host list")
-                Client.failedHosts.set(this.host, Client.hostServerInfo.get(this.host))
+                Client.failedHosts.set(this.host, Client.hostServerInfoPrimary.get(this.host))
                 let start = new Date().getTime();
                 Client.failedHostsTime.set(this.host, start)
                 Client.connectionMap.delete(this.host)
-                Client.hostServerInfo.delete(this.host)
+                Client.hostServerInfoPrimary.delete(this.host)
+              } else if (Client.hostServerInfoRR.has(this.host)) {
+                logger.debug("Adding " + this.host + " to failed host list")
+                Client.failedHosts.set(this.host, Client.hostServerInfoRR.get(this.host))
+                let start = new Date().getTime();
+                Client.failedHostsTime.set(this.host, start)
+                Client.connectionMap.delete(this.host)
+                Client.hostServerInfoRR.delete(this.host)
               } else if (Client.failedHosts.has(this.host)) {
                 logger.silly("Removing host " + this.host + " from failed hosts")
                 Client.failedHosts.delete(this.host)
@@ -641,14 +758,21 @@ class Client extends EventEmitter {
       this._connect((error) => {
         if (error) {
           logger.silly("Not able to connect to " + this.host + " due to error " + error.message)
-          if (this.connectionParameters.loadBalance && Client.hostServerInfo.size !== 0) {
-            if (Client.hostServerInfo.has(this.host)) {
+          if (this.connectionParameters.loadBalance && (Client.hostServerInfoPrimary.size !== 0 || Client.hostServerInfoRR.size !== 0)) {
+            if (Client.hostServerInfoPrimary.has(this.host)) {
               logger.debug("Adding " + this.host + " to failed host list")
-              Client.failedHosts.set(this.host, Client.hostServerInfo.get(this.host))
+              Client.failedHosts.set(this.host, Client.hostServerInfoPrimary.get(this.host))
               let start = new Date().getTime();
               Client.failedHostsTime.set(this.host, start)
               Client.connectionMap.delete(this.host)
-              Client.hostServerInfo.delete(this.host)
+              Client.hostServerInfoPrimary.delete(this.host)
+            } else if (Client.hostServerInfoRR.has(this.host)) {
+              logger.debug("Adding " + this.host + " to failed host list")
+              Client.failedHosts.set(this.host, Client.hostServerInfoRR.get(this.host))
+              let start = new Date().getTime();
+              Client.failedHostsTime.set(this.host, start)
+              Client.connectionMap.delete(this.host)
+              Client.hostServerInfoRR.delete(this.host)
             } else if (Client.failedHosts.has(this.host)) {
               logger.silly("Removing host " + this.host + " from failed host list")
               Client.failedHosts.delete(this.host)
@@ -672,7 +796,7 @@ class Client extends EventEmitter {
 
   updateConnectionMapAfterRefresh() {
     logger.silly("Updating connection map after refresh")
-    let hostsInfoList = Client.hostServerInfo.keys()
+    let hostsInfoList = [...Client.hostServerInfoPrimary.keys(), ...Client.hostServerInfoRR.keys()]
     for (let eachHost of hostsInfoList) {
       if (!Client.connectionMap.has(eachHost)) {
         if(!Client.failedHosts.has(eachHost)){
@@ -690,7 +814,7 @@ class Client extends EventEmitter {
     }
     let connectionMapHostList = Client.connectionMap.keys()
     for (let eachHost of connectionMapHostList) {
-      if (!Client.hostServerInfo.has(eachHost)) {
+      if (!Client.hostServerInfoPrimary.has(eachHost) && !Client.hostServerInfoRR.has(eachHost)) {
         Client.connectionMap.delete(eachHost)
       }
     }

--- a/packages/pg/lib/client.js
+++ b/packages/pg/lib/client.js
@@ -835,7 +835,20 @@ class Client extends EventEmitter {
               return this.nowConnect(callback)
             })
         } else {
-          return this.nowConnect(callback)
+          let res = this.nowConnect(callback);
+
+          if (res instanceof Promise) {
+            return res
+              .then(result => {
+                return result;
+              })
+              .catch(error => {
+                lock.release();
+                throw error;
+              });
+          } else {
+            return res;
+          }
         }
       }
     })

--- a/packages/pg/lib/client.js
+++ b/packages/pg/lib/client.js
@@ -133,10 +133,6 @@ class Client extends EventEmitter {
   static failedHosts = new Map()
   // Map of failedHost -> Time at which host was added to failedHosts Map
   static failedHostsTime = new Map()
-  // Map of placementInfoOfHost -> list of Primary Hosts
-  static placementInfoHostMapPrimary = new Map()
-  // Map of placementInfoOfHost -> list of RR Hosts
-  static placementInfoHostMapRR = new Map()
   // Map of Primary Host -> ServerInfo
   static hostServerInfoPrimary = new Map()
   // Map of RR Host -> ServerInfo
@@ -163,7 +159,7 @@ class Client extends EventEmitter {
   }
 
   getLeastLoadedServer(hostsList) {
-    logger.silly("getLeastLoadedServer() is called")
+    logger.silly("getLeastLoadedServer(): hostsList" + [...hostsList])
     if (hostsList.size === 0) {
       return this.host
     }
@@ -177,7 +173,7 @@ class Client extends EventEmitter {
     } else {
       hostServerInfo = new Map(Client.hostServerInfoRR);
     }
-
+    let minConnectionCount = Number.MAX_VALUE
     let leastLoadedHosts = []
     for (var i = 1; i <= Client.topologyKeyMap.size; i++) {
       let hosts = hostsList.keys()
@@ -214,7 +210,7 @@ class Client extends EventEmitter {
 
     if (leastLoadedHosts.length === 0) {
       if (!(this.connectionParameters.loadBalance === 'prefer-primary' || this.connectionParameters.loadBalance === 'prefer-rr')) {
-        if (Client.topologyKeyMap.size === 0 && !this.connectionParameters.fallbackToTopologyKeysOnly) {
+        if (Client.topologyKeyMap.size === 0 || !this.connectionParameters.fallbackToTopologyKeysOnly) {
           leastLoadedHosts = this.getHosts(hostsList, hostServerInfo)
         }
       } else {
@@ -314,7 +310,7 @@ class Client extends EventEmitter {
   _connect(callback) {
     logger.silly("connect() is called")
     var self = this
-    if (this.connectionParameters.loadBalance != 'false' && this._connecting) {
+    if (this.connectionParameters.loadBalance !== 'false' && this._connecting) {
       this.connection =
         this.config.connection ||
         new Connection({
@@ -344,7 +340,7 @@ class Client extends EventEmitter {
         con.stream.destroy(new Error('timeout expired'))
       }, this._connectionTimeoutMillis)
     }
-    if (this.connectionParameters.loadBalance != 'false') {
+    if (this.connectionParameters.loadBalance !== 'false') {
       if (Client.connectionMap.size && (Client.hostServerInfoPrimary.size || Client.hostServerInfoRR.size)) {
         this.host = this.getLeastLoadedServer(Client.connectionMap)
         if (Client.hostServerInfoPrimary.has(this.host)) {
@@ -581,42 +577,24 @@ class Client extends EventEmitter {
   createServersList(data) {
     logger.silly("Creating servers list")
     Client.hostServerInfoPrimary.clear()
-    Client.placementInfoHostMapPrimary.clear()
     Client.hostServerInfoRR.clear()
-    Client.placementInfoHostMapRR.clear()
     data.forEach((eachServer) => {
       var placementInfo = eachServer.cloud + '.' + eachServer.region + '.' + eachServer.zone
       var nodeType = eachServer.node_type
       var server = new ServerInfo(eachServer.host, eachServer.port, placementInfo, eachServer.public_ip, eachServer.node_type)
       if (nodeType === 'primary') {
-        if (Client.placementInfoHostMapPrimary.has(placementInfo)) {
-          let currentHosts = Client.placementInfoHostMapPrimary.get(placementInfo)
-          currentHosts.push(eachServer.host)
-          Client.placementInfoHostMapPrimary.set(placementInfo, currentHosts)
-        } else {
-          Client.placementInfoHostMapPrimary.set(placementInfo, [eachServer.host])
-        }
         Client.hostServerInfoPrimary.set(eachServer.host, server)
         if (eachServer.public_ip === this.host) {
           Client.usePublic = true
         }
       } else {
-        if (Client.placementInfoHostMapRR.has(placementInfo)) {
-          let currentHosts = Client.placementInfoHostMapRR.get(placementInfo)
-          currentHosts.push(eachServer.host)
-          Client.placementInfoHostMapRR.set(placementInfo, currentHosts)
-        } else {
-          Client.placementInfoHostMapRR.set(placementInfo, [eachServer.host])
-        }
         Client.hostServerInfoRR.set(eachServer.host, server)
         if (eachServer.public_ip === this.host) {
           Client.usePublic = true
         }
       }
     })
-    logger.debug("Updated placementInfoHostPrimary Map " + [...Client.placementInfoHostMapPrimary])
     logger.debug("Updated hostServerInfoPrimary to " + [...Client.hostServerInfoPrimary] + " and usePublic to " + Client.usePublic)
-    logger.debug("Updated placementInfoHostRR Map " + [...Client.placementInfoHostMapRR])
     logger.debug("Updated hostServerInfoRR to " + [...Client.hostServerInfoRR] + " and usePublic to " + Client.usePublic)
   }
 
@@ -684,10 +662,10 @@ class Client extends EventEmitter {
     logger.silly("nowConnect() is called...")
     if (callback) {
       logger.silly("callback is not null")
-      if (this.connectionParameters.loadBalance != 'false') {
+      if (this.connectionParameters.loadBalance !== 'false') {
         this._connect((error) => {
           if (error) {
-            if (this.connectionParameters.loadBalance != 'false') {
+            if (this.connectionParameters.loadBalance !== 'false') {
               if (Client.hostServerInfoPrimary.has(this.host)) {
                 logger.debug("Adding " + this.host + " to failed host list")
                 Client.failedHosts.set(this.host, Client.hostServerInfoPrimary.get(this.host))
@@ -714,7 +692,7 @@ class Client extends EventEmitter {
               return
             }
           } else {
-            if (this.connectionParameters.loadBalance != 'false') {
+            if (this.connectionParameters.loadBalance !== 'false') {
               lock.release()
               this.incrementConnectionCount()
             }
@@ -732,7 +710,7 @@ class Client extends EventEmitter {
       this._connect((error) => {
         if (error) {
           logger.silly("Not able to connect to " + this.host + " due to error " + error.message)
-          if (this.connectionParameters.loadBalance != 'false' && (Client.hostServerInfoPrimary.size !== 0 || Client.hostServerInfoRR.size !== 0)) {
+          if (this.connectionParameters.loadBalance !== 'false' && (Client.hostServerInfoPrimary.size !== 0 || Client.hostServerInfoRR.size !== 0)) {
             if (Client.hostServerInfoPrimary.has(this.host)) {
               logger.debug("Adding " + this.host + " to failed host list")
               Client.failedHosts.set(this.host, Client.hostServerInfoPrimary.get(this.host))
@@ -758,7 +736,7 @@ class Client extends EventEmitter {
             reject(error)
           }
         } else {
-          if (this.connectionParameters.loadBalance != 'false') {
+          if (this.connectionParameters.loadBalance !== 'false') {
             lock.release()
             this.incrementConnectionCount()
           }
@@ -987,7 +965,7 @@ class Client extends EventEmitter {
   _handleErrorWhileConnecting(err) {
     if (this._connectionError) {
       // TODO(bmc): this is swallowing errors - we shouldn't do this
-      if (this.connectionParameters.loadBalance != 'false' || Client.controlClient === undefined) {
+      if (this.connectionParameters.loadBalance !== 'false' || Client.controlClient === undefined) {
         if (this._connectionCallback) {
           return this._connectionCallback(err)
         }
@@ -1303,7 +1281,7 @@ class Client extends EventEmitter {
     }
 
     lock.acquire().then(() => {
-      if (this.connectionParameters.loadBalance != 'false') {
+      if (this.connectionParameters.loadBalance !== 'false') {
         let prevCount = Client.connectionMap.get(this.host)
         if (prevCount > 0) {
           logger.debug("Decreasing connection count (" + prevCount + ") of " + this.host + " by 1")

--- a/packages/pg/lib/client.js
+++ b/packages/pg/lib/client.js
@@ -68,6 +68,8 @@ class Client extends EventEmitter {
     this.loadBalance = this.connectionParameters.loadBalance
     this.topologyKeys = this.connectionParameters.topologyKeys
     this.ybServersRefreshInterval = this.connectionParameters.ybServersRefreshInterval
+    this.fallbackToTopologyKeysOnly = this.connectionParameters.fallbackToTopologyKeysOnly
+    this.failedHostReconnectDelaySecs = this.connectionParameters.failedHostReconnectDelaySecs
     this.connectionString = config
     // "hiding" the password so it doesn't show up in stack traces
     // or if the client is console.logged
@@ -176,7 +178,6 @@ class Client extends EventEmitter {
       hostServerInfo = new Map(Client.hostServerInfoRR);
     }
 
-    let minConnectionCount = Number.MAX_VALUE
     let leastLoadedHosts = []
     for (var i = 1; i <= Client.topologyKeyMap.size; i++) {
       let hosts = hostsList.keys()
@@ -212,84 +213,56 @@ class Client extends EventEmitter {
     }
 
     if (leastLoadedHosts.length === 0) {
-      let hosts = hostsList.keys()
-      for (let value of hosts) {
-        if (!hostServerInfo.has(value)) {
-          continue
+      if (!(this.connectionParameters.loadBalance === 'prefer-primary' || this.connectionParameters.loadBalance === 'prefer-rr')) {
+        if (Client.topologyKeyMap.size === 0 && !this.connectionParameters.fallbackToTopologyKeysOnly) {
+          leastLoadedHosts = this.getHosts(hostsList, hostServerInfo)
         }
-        let hostCount
-        if (typeof hostsList.get(value) === 'object') {
-          hostCount = 0
-        } else {
-          hostCount = hostsList.get(value)
-        }
-        if (minConnectionCount > hostCount) {
-          leastLoadedHosts = []
-          minConnectionCount = hostCount
-          leastLoadedHosts.push(value)
-        } else if (minConnectionCount === hostCount) {
-          leastLoadedHosts.push(value)
-        }
-      }
-    }
-    if (leastLoadedHosts.length === 0) {
-      if (this.connectionParameters.loadBalance != 'prefer-primary' || this.connectionParameters.loadBalance != 'prefer-rr') {
-        return this.host
       } else {
-        if (this.connectionParameters.loadBalance === 'prefer-primary'){
-          hostServerInfo = new Map(Client.hostServerInfoRR);
-          let hosts = hostsList.keys()
-          for (let value of hosts) {
-            if (!hostServerInfo.has(value)) {
-              continue
-            }
-            let hostCount
-            if (typeof hostsList.get(value) === 'object') {
-              hostCount = 0
-            } else {
-              hostCount = hostsList.get(value)
-            }
-            if (minConnectionCount > hostCount) {
-              leastLoadedHosts = []
-              minConnectionCount = hostCount
-              leastLoadedHosts.push(value)
-            } else if (minConnectionCount === hostCount) {
-              leastLoadedHosts.push(value)
-            }
-          }
-        } else {
-          hostServerInfo = new Map(Client.hostServerInfoPrimary);
-          let hosts = hostsList.keys()
-          for (let value of hosts) {
-            if (!hostServerInfo.has(value)) {
-              continue
-            }
-            let hostCount
-            if (typeof hostsList.get(value) === 'object') {
-              hostCount = 0
-            } else {
-              hostCount = hostsList.get(value)
-            }
-            if (minConnectionCount > hostCount) {
-              leastLoadedHosts = []
-              minConnectionCount = hostCount
-              leastLoadedHosts.push(value)
-            } else if (minConnectionCount === hostCount) {
-              leastLoadedHosts.push(value)
-            }
+        leastLoadedHosts = this.getHosts(hostsList, hostServerInfo)
+        if (leastLoadedHosts.length === 0) {
+          if (this.connectionParameters.loadBalance === 'prefer-primary'){
+            leastLoadedHosts = this.getHosts(hostsList, new Map(Client.hostServerInfoRR))
+          } else {
+            leastLoadedHosts = this.getHosts(hostsList, new Map(Client.hostServerInfoPrimary))
           }
         }
       }
     }
 
     if (leastLoadedHosts.length === 0) {
-      return this.host
+      throw new Error('Could not find a least loaded server.')
     }
     let randomIdx = Math.floor(Math.random() * leastLoadedHosts.length - 1) + 1
     let leastLoadedHost = leastLoadedHosts[randomIdx]
     logger.silly("Least loaded servers are " + leastLoadedHosts)
     logger.debug("Returning " + leastLoadedHost + " as the least loaded host")
     return leastLoadedHost
+  }
+
+  getHosts(hostsList, hostServerInfo) {
+    let minConnectionCount = Number.MAX_VALUE
+    let leastLoadedHosts = []
+
+    let hosts = hostsList.keys()
+    for (let value of hosts) {
+      if (!hostServerInfo.has(value)) {
+        continue
+      }
+      let hostCount
+      if (typeof hostsList.get(value) === 'object') {
+        hostCount = 0
+      } else {
+        hostCount = hostsList.get(value)
+      }
+      if (minConnectionCount > hostCount) {
+        leastLoadedHosts = []
+        minConnectionCount = hostCount
+        leastLoadedHosts.push(value)
+      } else if (minConnectionCount === hostCount) {
+        leastLoadedHosts.push(value)
+      }
+    }
+    return leastLoadedHosts
   }
 
   isValidKey(key) {
@@ -341,7 +314,7 @@ class Client extends EventEmitter {
   _connect(callback) {
     logger.silly("connect() is called")
     var self = this
-    if (this.connectionParameters.loadBalance && this._connecting) {
+    if (this.connectionParameters.loadBalance != 'false' && this._connecting) {
       this.connection =
         this.config.connection ||
         new Connection({
@@ -371,7 +344,7 @@ class Client extends EventEmitter {
         con.stream.destroy(new Error('timeout expired'))
       }, this._connectionTimeoutMillis)
     }
-    if (this.connectionParameters.loadBalance) {
+    if (this.connectionParameters.loadBalance != 'false') {
       if (Client.connectionMap.size && (Client.hostServerInfoPrimary.size || Client.hostServerInfoRR.size)) {
         this.host = this.getLeastLoadedServer(Client.connectionMap)
         if (Client.hostServerInfoPrimary.has(this.host)) {
@@ -541,8 +514,8 @@ class Client extends EventEmitter {
       addresses = res
     })
     client.host = addresses[0].address // If both resolved then - IPv6 else IPv4
-    client.loadBalance = false
-    client.connectionParameters.loadBalance = false
+    client.loadBalance = 'false'
+    client.connectionParameters.loadBalance = 'false'
     client.topologyKeys = ''
     client.connectionParameters.topologyKeys = ''
     if (Client.failedHosts.has(client.host)) {
@@ -710,10 +683,10 @@ class Client extends EventEmitter {
     logger.silly("nowConnect() is called...")
     if (callback) {
       logger.silly("callback is not null")
-      if (this.connectionParameters.loadBalance) {
+      if (this.connectionParameters.loadBalance != 'false') {
         this._connect((error) => {
           if (error) {
-            if (this.connectionParameters.loadBalance) {
+            if (this.connectionParameters.loadBalance != 'false') {
               if (Client.hostServerInfoPrimary.has(this.host)) {
                 logger.debug("Adding " + this.host + " to failed host list")
                 Client.failedHosts.set(this.host, Client.hostServerInfoPrimary.get(this.host))
@@ -740,7 +713,7 @@ class Client extends EventEmitter {
               return
             }
           } else {
-            if (this.connectionParameters.loadBalance) {
+            if (this.connectionParameters.loadBalance != 'false') {
               lock.release()
               this.incrementConnectionCount()
             }
@@ -758,7 +731,7 @@ class Client extends EventEmitter {
       this._connect((error) => {
         if (error) {
           logger.silly("Not able to connect to " + this.host + " due to error " + error.message)
-          if (this.connectionParameters.loadBalance && (Client.hostServerInfoPrimary.size !== 0 || Client.hostServerInfoRR.size !== 0)) {
+          if (this.connectionParameters.loadBalance != 'false' && (Client.hostServerInfoPrimary.size !== 0 || Client.hostServerInfoRR.size !== 0)) {
             if (Client.hostServerInfoPrimary.has(this.host)) {
               logger.debug("Adding " + this.host + " to failed host list")
               Client.failedHosts.set(this.host, Client.hostServerInfoPrimary.get(this.host))
@@ -784,7 +757,7 @@ class Client extends EventEmitter {
             reject(error)
           }
         } else {
-          if (this.connectionParameters.loadBalance) {
+          if (this.connectionParameters.loadBalance != 'false') {
             lock.release()
             this.incrementConnectionCount()
           }
@@ -842,7 +815,7 @@ class Client extends EventEmitter {
   }
 
   connect(callback) {
-    if (!this.connectionParameters.loadBalance) {
+    if (this.connectionParameters.loadBalance === 'false') {
       logger.silly("Loadbalance is false, falling to upstream behaviour")
       return this.nowConnect(callback)
     }
@@ -1013,7 +986,7 @@ class Client extends EventEmitter {
   _handleErrorWhileConnecting(err) {
     if (this._connectionError) {
       // TODO(bmc): this is swallowing errors - we shouldn't do this
-      if (this.connectionParameters.loadBalance || Client.controlClient === undefined) {
+      if (this.connectionParameters.loadBalance != 'false' || Client.controlClient === undefined) {
         if (this._connectionCallback) {
           return this._connectionCallback(err)
         }
@@ -1329,14 +1302,14 @@ class Client extends EventEmitter {
     }
 
     lock.acquire().then(() => {
-      if (this.connectionParameters.loadBalance) {
+      if (this.connectionParameters.loadBalance != 'false') {
         let prevCount = Client.connectionMap.get(this.host)
         if (prevCount > 0) {
           logger.debug("Decreasing connection count (" + prevCount + ") of " + this.host + " by 1")
           Client.connectionMap.set(this.host, prevCount - 1)
         }
-        lock.release()
       }
+      lock.release()
     })
 
     if (cb) {

--- a/packages/pg/lib/client.js
+++ b/packages/pg/lib/client.js
@@ -173,6 +173,7 @@ class Client extends EventEmitter {
     } else {
       hostServerInfo = new Map(Client.hostServerInfoRR);
     }
+    logger.silly("Potential hosts: " + [...hostServerInfo])
     let minConnectionCount = Number.MAX_VALUE
     let leastLoadedHosts = []
     for (var i = 1; i <= Client.topologyKeyMap.size; i++) {
@@ -409,7 +410,6 @@ class Client extends EventEmitter {
           }
         } else if (!this._connectionError) {
           if (Client.controlClientHost === this.host && Client.controlClient != undefined) {
-            console.log("Control Connection host might be down, marking control connection as undefined")
             logger.silly("Control Connection host might be down, marking control connection as undefined")
             Client.controlClient = undefined
           }
@@ -426,14 +426,14 @@ class Client extends EventEmitter {
   attachErrorListenerOnClientConnection(client) {
     client.on('error', () => {
       if (Client.hostServerInfoPrimary.has(client.host)) {
-        logger.debug("Not able to connect to host " + client.host + " adding it to failedHosts")
+        logger.debug("Not able to connect to primary host " + client.host + ", adding it to failedHosts")
         Client.failedHosts.set(client.host, Client.hostServerInfoPrimary.get(client.host))
         let start = new Date().getTime();
         Client.failedHostsTime.set(client.host, start)
         Client.connectionMap.delete(client.host)
         Client.hostServerInfoPrimary.delete(client.host)
       } else if (Client.hostServerInfoRR.has(client.host)) {
-        logger.debug("Not able to connect to host " + client.host + " adding it to failedHosts")
+        logger.debug("Not able to connect to read replica host " + client.host + ", adding it to failedHosts")
         Client.failedHosts.set(client.host, Client.hostServerInfoRR.get(client.host))
         let start = new Date().getTime();
         Client.failedHostsTime.set(client.host, start)
@@ -446,6 +446,9 @@ class Client extends EventEmitter {
   }
 
   async iterateHostList(client) {
+    logger.silly("hostServerInfoPrimary: " + [...Client.hostServerInfoPrimary])
+    logger.silly("hostServerInfoRR: " + [...Client.hostServerInfoRR])
+    logger.silly("failedHosts: " + [...Client.failedHosts])
     let upHostsList = [...Client.hostServerInfoPrimary.keys(), ...Client.hostServerInfoRR.keys()][Symbol.iterator]()
     let upHost = upHostsList.next()
     let hostIsUp = false
@@ -611,7 +614,6 @@ class Client extends EventEmitter {
         }
       } else {
         let start = new Date().getTime();
-        logger.silly("failedHostReconnectDelaySecs is set to: " + this.connectionParameters.failedHostReconnectDelaySecs)
         if (start - Client.failedHostsTime.get(eachServer.host) > (this.connectionParameters.failedHostReconnectDelaySecs * 1000)) {
           logger.debug("Removing " + eachServer.host + " from failed host list")
           Client.connectionMap.set(eachServer.host, 0)
@@ -799,6 +801,11 @@ class Client extends EventEmitter {
       return this.nowConnect(callback)
     }
     lock.acquire().then(() => {
+      logger.silly("loadBalance: " + this.connectionParameters.loadBalance)
+      logger.silly("topologyKeys: " + this.connectionParameters.topologyKeys)
+      logger.silly("ybServersRefreshInterval: " + this.connectionParameters.ybServersRefreshInterval)
+      logger.silly("fallbackToTopologyKeysOnly: " + this.connectionParameters.fallbackToTopologyKeysOnly)
+      logger.silly("failedHostReconnectDelaySecs: " + this.connectionParameters.failedHostReconnectDelaySecs)
       if (Client.controlClient === undefined) {
         this.getConnection()
           .then(async (res) => {
@@ -843,6 +850,7 @@ class Client extends EventEmitter {
                 return result;
               })
               .catch(error => {
+                logger.silly("Releasing lock.")
                 lock.release();
                 throw error;
               });

--- a/packages/pg/lib/connection-parameters.js
+++ b/packages/pg/lib/connection-parameters.js
@@ -114,7 +114,7 @@ class ConnectionParameters {
       }
     }
     if (this.topologyKeys !== '') {
-      if (this.loadBalance !== 'false') {
+      if (this.loadBalance === 'false') {
         throw new Error(' You need to enable Load Balance feature to use Topology Aware! ')
       }
     }

--- a/packages/pg/lib/connection-parameters.js
+++ b/packages/pg/lib/connection-parameters.js
@@ -112,6 +112,12 @@ class ConnectionParameters {
         default:
           throw new Error('Invalid loadBalance value: Valid values are only-rr, only-primary, prefer-rr, prefer-primary, any or true');
       }
+    } else if (typeof this.loadBalance === 'boolean') {
+      if (this.loadBalance) {
+        this.loadBalance = 'true'
+      } else {
+        this.loadBalance = 'false'
+      }
     }
     if (this.topologyKeys !== '') {
       if (this.loadBalance === 'false') {

--- a/packages/pg/lib/connection-parameters.js
+++ b/packages/pg/lib/connection-parameters.js
@@ -100,7 +100,7 @@ class ConnectionParameters {
     this.failedHostReconnectDelaySecs = val('failedHostReconnectDelaySecs', config)
 
     if (typeof this.loadBalance === 'string') {
-      switch(this.loadBalance.toLowerCase()) {
+      switch (this.loadBalance.toLowerCase()) {
         case 'true':
         case 'any':
         case 'prefer-primary':
@@ -125,20 +125,20 @@ class ConnectionParameters {
       }
     }
     this.ybServersRefreshInterval = Number(this.ybServersRefreshInterval)
-    if(isNaN(this.ybServersRefreshInterval) || !Number.isInteger(this.ybServersRefreshInterval)){
+    if (isNaN(this.ybServersRefreshInterval) || !Number.isInteger(this.ybServersRefreshInterval)) {
       throw new Error(' You need to Enter valid Refresh Interval ')
     }
-    if(this.ybServersRefreshInterval<0 || this.ybServersRefreshInterval>600){
+    if (this.ybServersRefreshInterval < 0 || this.ybServersRefreshInterval > 600) {
       this.ybServersRefreshInterval = 300
     }
     if (typeof this.fallbackToTopologyKeysOnly === 'string') {
       this.fallbackToTopologyKeysOnly = this.fallbackToTopologyKeysOnly === 'true'
     }
     this.failedHostReconnectDelaySecs = Number(this.failedHostReconnectDelaySecs)
-    if(isNaN(this.failedHostReconnectDelaySecs) || !Number.isInteger(this.failedHostReconnectDelaySecs)){
-      throw new Error(' You need to Enter valid failedHostReconnectDelaySecs')
+    if (isNaN(this.failedHostReconnectDelaySecs) || !Number.isInteger(this.failedHostReconnectDelaySecs)) {
+      throw new Error('Enter a valid value for failedHostReconnectDelaySecs')
     }
-    if(this.failedHostReconnectDelaySecs<0 || this.failedHostReconnectDelaySecs>60){
+    if (this.failedHostReconnectDelaySecs < 0 || this.failedHostReconnectDelaySecs > 60) {
       this.failedHostReconnectDelaySecs = 5
     }
     this.client_encoding = val('client_encoding', config)

--- a/packages/pg/lib/connection-parameters.js
+++ b/packages/pg/lib/connection-parameters.js
@@ -98,7 +98,18 @@ class ConnectionParameters {
     this.ybServersRefreshInterval = val('ybServersRefreshInterval', config)
 
     if (typeof this.loadBalance === 'string') {
-      this.loadBalance = this.loadBalance === 'true'
+      switch(this.loadBalance.toLowerCase()) {
+        case 'true':
+        case 'any':
+        case 'prefer-primary':
+        case 'prefer-rr':
+        case 'only-primary':
+        case 'only-rr':
+        case 'false':
+          break;
+        default:
+          throw new Error('Invalid loadBalance value: Valid values are only-rr, only-primary, prefer-rr, prefer-primary, any or true');
+      }
     }
     if (this.topologyKeys !== '') {
       if (!this.loadBalance) {

--- a/packages/pg/lib/connection-parameters.js
+++ b/packages/pg/lib/connection-parameters.js
@@ -96,6 +96,8 @@ class ConnectionParameters {
     this.loadBalance = val('loadBalance', config)
     this.topologyKeys = val('topologyKeys', config)
     this.ybServersRefreshInterval = val('ybServersRefreshInterval', config)
+    this.fallbackToTopologyKeysOnly = val('fallbackToTopologyKeysOnly', config)
+    this.failedHostReconnectDelaySecs = val('failedHostReconnectDelaySecs', config)
 
     if (typeof this.loadBalance === 'string') {
       switch(this.loadBalance.toLowerCase()) {
@@ -112,7 +114,7 @@ class ConnectionParameters {
       }
     }
     if (this.topologyKeys !== '') {
-      if (!this.loadBalance) {
+      if (this.loadBalance !== 'false') {
         throw new Error(' You need to enable Load Balance feature to use Topology Aware! ')
       }
     }
@@ -122,6 +124,16 @@ class ConnectionParameters {
     }
     if(this.ybServersRefreshInterval<0 || this.ybServersRefreshInterval>600){
       this.ybServersRefreshInterval = 300
+    }
+    if (typeof this.fallbackToTopologyKeysOnly === 'string') {
+      this.fallbackToTopologyKeysOnly = this.fallbackToTopologyKeysOnly === 'true'
+    }
+    this.failedHostReconnectDelaySecs = Number(this.failedHostReconnectDelaySecs)
+    if(isNaN(this.failedHostReconnectDelaySecs) || !Number.isInteger(this.failedHostReconnectDelaySecs)){
+      throw new Error(' You need to Enter valid failedHostReconnectDelaySecs')
+    }
+    if(this.failedHostReconnectDelaySecs<0 || this.failedHostReconnectDelaySecs>60){
+      this.failedHostReconnectDelaySecs = 5
     }
     this.client_encoding = val('client_encoding', config)
     this.replication = val('replication', config)
@@ -163,6 +175,8 @@ class ConnectionParameters {
     add(params, this, 'loadBalance')
     add(params, this, 'topologyKeys')
     add(params, this, 'ybServersRefreshInterval')
+    add(params, this, 'fallbackToTopologyKeysOnly')
+    add(params, this, 'failedHostReconnectDelaySecs')
 
     var ssl = typeof this.ssl === 'object' ? this.ssl : this.ssl ? { sslmode: this.ssl } : {}
     add(params, ssl, 'sslmode')

--- a/packages/pg/lib/defaults.js
+++ b/packages/pg/lib/defaults.js
@@ -30,8 +30,10 @@ module.exports = {
   // Refresh Interval
   ybServersRefreshInterval: 300,
 
+  // Fallback to Topology keys only
   fallbackToTopologyKeysOnly: false,
 
+  // Failed host reconnect delay seconds
   failedHostReconnectDelaySecs: 5,
 
   // number of rows to return at a time from a prepared statement's

--- a/packages/pg/lib/defaults.js
+++ b/packages/pg/lib/defaults.js
@@ -22,13 +22,17 @@ module.exports = {
   port: 5433,
 
   // Load Balance feature variable
-  loadBalance: false,
+  loadBalance: 'false',
 
   // Topology keys
   topologyKeys: '',
 
   // Refresh Interval
   ybServersRefreshInterval: 300,
+
+  fallbackToTopologyKeysOnly: false,
+
+  failedHostReconnectDelaySecs: 5,
 
   // number of rows to return at a time from a prepared statement's
   // portal. 0 will return all rows at once

--- a/packages/pg/package.json
+++ b/packages/pg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yugabytedb/pg",
-  "version": "8.7.3-yb-8",
+  "version": "8.7.3-yb-9",
   "description": "Pure JavaScript PostgreSQL client and native libpq bindings with YugabyteDB smart-driver features",
   "keywords": [
     "database",
@@ -20,8 +20,8 @@
   },
   "author": "Brian Carlson <brian.m.carlson@gmail.com>",
   "contributors": [
-     "Priyanshi Gupta <pgupta@yugabyte.com>",
-     "Harsh Daryani <hdaryani@yugabyte.com>"
+    "Priyanshi Gupta <pgupta@yugabyte.com>",
+    "Harsh Daryani <hdaryani@yugabyte.com>"
   ],
   "main": "./lib",
   "dependencies": {
@@ -60,6 +60,6 @@
     "node": ">= 8.0.0"
   },
   "publishConfig": {
-   "access": "public"
+    "access": "public"
   }
 }


### PR DESCRIPTION
IDEA: [IDEA-1197](https://yugabyte.atlassian.net/browse/IDEA-1197)

Implementation details: [Doc](https://docs.google.com/document/d/1SqT7IMM5DuHav7fl_xGt8pfCMp5dnJ6-MrLVftbIows/edit#heading=h.4p1zl0z1krwh)

The connection property `loadBalance` currently allows only two values, viz. `false` (the default) and `true`.

It will now also allow below five new values to be specified:
`only-rr` - Create connections only on Read Replica nodes
`only-primary`- Create connections only on primary cluster nodes
`prefer-rr` - Create connections on Read Replica nodes. If none available, on any node in the cluster including primary cluster nodes
`prefer-primary` - Create connections on primary cluster nodes. If none available, on any node in the cluster including Read Replica nodes
`any` - Equivalent to value true. Create connections on any node in the primary or Read Replica cluster

default value is still `false`

Other Minor changes:

- Added the following 2 new connection properties: `fallbackToTopologyKeysOnly`  and `failedHostReconnectDelaySecs`

**Testing:**
Test cases identified and listed in this [doc](https://docs.google.com/document/d/1gBxuv1mgTszGAoleYV1_fQdZxIGC-dssCN3XfKuSA2A/edit).
Test for all test cases listed in the doc added to driver-example repo: [PR LINK](https://github.com/yugabyte/driver-examples/pull/25).
Ran the existing and new tests in driver examples repo for node-postgres.