### PR TITLE
Changing upstream pg and pg-pool to respection yugabytedb versions

### DIFF
--- a/packages/pg-pool/package.json
+++ b/packages/pg-pool/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yugabytedb/pg-pool",
-  "version": "3.5.1-yb-1",
+  "version": "3.5.1-yb-3",
   "description": "Connection pool for node-postgres",
   "main": "index.js",
   "directories": {
@@ -35,7 +35,7 @@
     "pg-cursor": "^1.3.0"
   },
   "peerDependencies": {
-    "pg": ">=8.0"
+    "@yugabytedb/pg": "*"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/pg/lib/index.js
+++ b/packages/pg/lib/index.js
@@ -3,7 +3,7 @@
 var Client = require('./client')
 var defaults = require('./defaults')
 var Connection = require('./connection')
-var Pool = require('pg-pool')
+var Pool = require('@yugabytedb/pg-pool')
 const { DatabaseError } = require('pg-protocol')
 
 const poolFactory = (Client) => {

--- a/packages/pg/package.json
+++ b/packages/pg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yugabytedb/pg",
-  "version": "8.7.3-yb-9",
+  "version": "8.7.3-yb-10",
   "description": "Pure JavaScript PostgreSQL client and native libpq bindings with YugabyteDB smart-driver features",
   "keywords": [
     "database",
@@ -28,7 +28,7 @@
     "buffer-writer": "2.0.0",
     "packet-reader": "1.0.0",
     "pg-connection-string": "^2.5.0",
-    "pg-pool": "^3.5.1",
+    "@yugabytedb/pg-pool": "^3.5.1-yb-3",
     "pg-protocol": "^1.5.0",
     "pg-types": "^2.1.0",
     "pgpass": "1.x",


### PR DESCRIPTION
Currently the @yugabytedb/pg package has upstream pg-pool as a dependency, this PR changes that to use yugabytedb/pg-pool and the @yugabytedb/pg-pool package has a peer-depencency to the upstream pg, this PR also changes that to use yugabytedb/pg. 