### PR TITLE
Changed the ports from 5432 to 5433

### DIFF
--- a/packages/pg/test/integration/client/configuration-tests.js
+++ b/packages/pg/test/integration/client/configuration-tests.js
@@ -16,7 +16,7 @@ suite.test('default values are used in new clients', function () {
     user: process.env.USER,
     database: undefined,
     password: null,
-    port: 5432,
+    port: 5433,
     rows: 0,
     max: 10,
     binary: false,
@@ -33,7 +33,7 @@ suite.test('default values are used in new clients', function () {
     user: process.env.USER,
     database: process.env.USER,
     password: null,
-    port: 5432,
+    port: 5433,
   })
 })
 

--- a/packages/pg/test/integration/connection/test-helper.js
+++ b/packages/pg/test/integration/connection/test-helper.js
@@ -11,7 +11,7 @@ var connect = function (callback) {
     console.log(error)
     throw new Error('Connection error')
   })
-  con.connect(helper.args.port || '5432', helper.args.host || 'localhost')
+  con.connect(helper.args.port || '5433', helper.args.host || 'localhost')
   con.once('connect', function () {
     con.startup({
       user: username,

--- a/packages/pg/test/unit/client/configuration-tests.js
+++ b/packages/pg/test/unit/client/configuration-tests.js
@@ -4,7 +4,7 @@ var assert = require('assert')
 
 var pguser = process.env['PGUSER'] || process.env.USER
 var pgdatabase = process.env['PGDATABASE'] || process.env.USER
-var pgport = process.env['PGPORT'] || 5432
+var pgport = process.env['PGPORT'] || 5433
 
 test('client settings', function () {
   test('defaults', function () {
@@ -92,7 +92,7 @@ test('initializing from a config string', function () {
     assert.equal(client.user, process.env['PGUSER'] || process.env.USER)
     assert.equal(client.password, process.env['PGPASSWORD'] || null)
     assert.equal(client.host, 'host1')
-    assert.equal(client.port, process.env['PGPORT'] || 5432)
+    assert.equal(client.port, process.env['PGPORT'] || 5433)
     assert.equal(client.database, process.env['PGDATABASE'] || process.env.USER)
   })
 


### PR DESCRIPTION
The Yugabyte fork sets the client default port to 5433 in packages/pg/lib/defaults.js. Several tests still assumed 5432 (upstream PostgreSQL), which caused failures like 5433 == 5432 in configuration tests and wrong fallbacks when PGPORT is unset.

This updates only expected values and fallbacks in test code so they match the fork’s default:

test/integration/client/configuration-tests.js — assert 5433 for pg.defaults.port and new Client().port when env is cleared
test/unit/client/configuration-tests.js — use 5433 when falling back from PGPORT
test/integration/connection/test-helper.js — default connect port string 5433 when args omit port