### PR TITLE
Fix promise-based connect() and orphan 'end' events during load-balan…

### DIFF
--- a/packages/pg/lib/client.js
+++ b/packages/pg/lib/client.js
@@ -391,6 +391,16 @@ class Client extends EventEmitter {
     this._attachListeners(con)
 
     con.once('end', () => {
+      // When load balancing is enabled, _connect() may replace `this.connection`
+      // with a new Connection on a different host as part of an internal retry.
+      // The old Connection's listeners stay attached and its socket eventually
+      // fires 'end'. If we ran the regular handler in that case we would call
+      // _errorAllQueries() and reject queries that belong to the new, healthy
+      // Connection. Detect the orphan and bail out.
+      if (this.connection !== con) {
+        logger.silly("Ignoring 'end' from orphan connection (Client moved to a different host)")
+        return
+      }
       const error = this._ending ? new Error('Connection terminated') : new Error('Connection terminated unexpectedly')
 
       clearTimeout(this.connectionTimeoutHandle)
@@ -796,6 +806,18 @@ class Client extends EventEmitter {
   }
 
   connect(callback) {
+    // When no callback is given, callers expect a Promise that resolves only
+    // after the connection (including any internal retry/failover) succeeds.
+    // The load-balance branch below wraps the work in `lock.acquire().then(...)`
+    // but does not return that chain, so the function would otherwise return
+    // `undefined` synchronously and `await client.connect()` would not actually
+    // wait. Wrap the callback-style path in a Promise here to make both forms
+    // behave consistently with upstream pg.
+    if (!callback) {
+      return new this._Promise((resolve, reject) => {
+        this.connect((err) => (err ? reject(err) : resolve(this)))
+      })
+    }
     if (this.connectionParameters.loadBalance === 'false') {
       logger.silly("Loadbalance is false, falling to upstream behaviour")
       return this.nowConnect(callback)

--- a/packages/pg/lib/client.js
+++ b/packages/pg/lib/client.js
@@ -553,6 +553,13 @@ class Client extends EventEmitter {
             logger.silly("Attempting to create control connection to " + client.host)
             await client.nowConnect()
           }
+        } else {
+          // Only a single address resolved (e.g. a literal seed IP) and it is
+          // unreachable. There is nothing left to retry, so surface the error
+          // instead of returning a never-connected control client, otherwise
+          // getServersInfo() would later query a dead client whose request
+          // never settles, hanging connect() forever.
+          throw err
         }
       })
     }
@@ -563,27 +570,21 @@ class Client extends EventEmitter {
 
   async getServersInfo() {
     logger.silly("Refreshing server info")
-    var client = Client.controlClient
-    var result
-    await client
-      .query({
+    const queryYbServers = (client) =>
+      client.query({
         text: YB_SERVERS_QUERY,
         statement_timeout: 10000, // Timeout after 10 seconds
       })
-      .then((res) => {
-        result = res
-      })
-      .catch((err) => {
-        this.getConnection()
-          .then(async (res) => {
-            Client.controlClient = res
-            await this.getServersInfo()
-          })
-          .catch((err) => {
-            return this.nowConnect(callback)
-          })
-      })
-    return result
+    try {
+      return await queryYbServers(Client.controlClient)
+    } catch (err) {
+      // The existing control connection is unusable. Rebuild it once and retry;
+      // if getConnection() cannot reach any node it rejects, and we propagate
+      // that error to the caller rather than swallowing it.
+      logger.silly("Control connection query failed (" + err.message + "). Recreating control connection.")
+      Client.controlClient = await this.getConnection()
+      return await queryYbServers(Client.controlClient)
+    }
   }
 
   createServersList(data) {
@@ -697,7 +698,15 @@ class Client extends EventEmitter {
                 Client.failedHostsTime.delete(this.host)
               }
               lock.release()
-              this.connect(callback)
+              // Only retry by re-entering connect() if there is server info to
+              // pick a different host from. With no metadata (e.g. the bootstrap
+              // host is down on the very first connect) re-entering would loop
+              // forever, so surface the error to the caller instead.
+              if (Client.hostServerInfoPrimary.size !== 0 || Client.hostServerInfoRR.size !== 0) {
+                this.connect(callback)
+              } else {
+                callback(error)
+              }
             } else {
               callback(error)
               return
@@ -834,25 +843,23 @@ class Client extends EventEmitter {
       logger.silly("failedHostReconnectDelaySecs: " + this.connectionParameters.failedHostReconnectDelaySecs)
       if (Client.controlClient === undefined) {
         return this.getConnection()
-          .then(async (res) => {
+          .then((res) => {
             Client.controlClient = res
-            this.getServersInfo()
-              .catch((err) => {
-                logger.silly("Not able to get servers info due to error " + err.message)
+            // Return the getServersInfo() chain so that connect() only settles
+            // once metadata has been built and nowConnect() has been called.
+            return this.getServersInfo()
+              .then((info) => {
+                this.createMetaData(info.rows)
                 return this.nowConnect(callback)
               })
-              .then((res) => {
-                try {
-                  this.createMetaData(res.rows)
-                  return this.nowConnect(callback)
-                } catch (err) {
-                  if (err.message.includes('Bad Topology Key found')) {
-                    throw err
-                  } else {
-                    //ToDo: Why not throw the error?
-                    logger.debug("Error caught: " + err.message)
-                  }
+              .catch((err) => {
+                if (err.message.includes('Bad Topology Key found')) {
+                  throw err
                 }
+                // Could not build metadata; fall back to a direct connection
+                // to the given host instead of hanging.
+                logger.silly("Not able to get servers info due to error " + err.message)
+                return this.nowConnect(callback)
               })
           })
           .catch((err) => {

--- a/packages/pg/lib/client.js
+++ b/packages/pg/lib/client.js
@@ -826,14 +826,14 @@ class Client extends EventEmitter {
     ToDo: We are holding the lock until the user connection gets created. 
     This looks like an overkill, why is this required?
     */
-    lock.acquire().then(() => {
+    return lock.acquire().then(() => {
       logger.silly("loadBalance: " + this.connectionParameters.loadBalance)
       logger.silly("topologyKeys: " + this.connectionParameters.topologyKeys)
       logger.silly("ybServersRefreshInterval: " + this.connectionParameters.ybServersRefreshInterval)
       logger.silly("fallbackToTopologyKeysOnly: " + this.connectionParameters.fallbackToTopologyKeysOnly)
       logger.silly("failedHostReconnectDelaySecs: " + this.connectionParameters.failedHostReconnectDelaySecs)
       if (Client.controlClient === undefined) {
-        this.getConnection()
+        return this.getConnection()
           .then(async (res) => {
             Client.controlClient = res
             this.getServersInfo()
@@ -861,7 +861,7 @@ class Client extends EventEmitter {
           })
       } else {
         if (this.isRefreshRequired()) {
-          this.getServersInfo()
+          return this.getServersInfo()
             .then((res) => {
               this.updateMetaData(res.rows)
               if (this.connectionParameters.topologyKeys !== '') {
@@ -891,6 +891,16 @@ class Client extends EventEmitter {
           }
         }
       }
+    })
+    .catch((err) => {
+      // A synchronous throw from the load-balance path above (e.g.
+      // getLeastLoadedServer() finding no eligible server, or topology-key
+      // parsing) would otherwise leak as an unhandled rejection while the user
+      // callback is never invoked -- so `await connect()` hangs forever -- and
+      // the lock acquired above is never released, deadlocking every later
+      // connect. Release the lock and surface the error through the callback.
+      lock.release()
+      callback(err)
     })
   }
 


### PR DESCRIPTION
Jira: [DB-21957](https://yugabyte.atlassian.net/browse/DB-21957)

## Summary

Fixes to `Client` in `packages/pg/lib/client.js` that surface when load balancing is enabled and `_connect()` performs an internal retry/failover to a different host, when no eligible server can be found, or when the bootstrap/seed host is unreachable on the very first connect.

## Changes

### 1. `connect()` returns a Promise when no callback is provided

The load-balance branch wraps its work in `lock.acquire().then(...)` but never returned that chain, so calling `connect()` without a callback returned `undefined` synchronously. As a result `await client.connect()` did not actually wait for the connection (including any internal retry/failover) to complete.

We now wrap the callback-style path in a Promise at the top of `connect()`, so both the callback and promise forms behave consistently with upstream `pg`.

### 2. Ignore `'end'` events from orphaned connections

During load-balanced failover, `_connect()` may replace `this.connection` with a new `Connection` on a different host. The old `Connection`'s listeners remain attached, and when its socket eventually fires `'end'`, the regular handler would call `_errorAllQueries()`: incorrectly rejecting queries that belong to the new, healthy connection.

The `'end'` handler now detects this case (`this.connection !== con`) and bails out early, logging at `silly` level.

### 3. Release the lock and surface the error when no server can be found

The load-balance branch returns its work as `lock.acquire().then(...)`, but a **synchronous** throw from that path: most commonly `getLeastLoadedServer()` raising `Error: Could not find a least loaded server.` (e.g. every eligible host is stopped), or topology-key parsing: was never handled. The rejection leaked as an unhandled promise rejection while the user callback was never invoked, so `await client.connect()` hung forever, and the lock acquired at the top of the branch was never released: deadlocking every subsequent `connect()`.

We now:
- `return` the `lock.acquire().then(...)` chain (and the inner `getConnection()` / `getServersInfo()` chains) so the failure propagates instead of being dropped, and
- add an outer `.catch()` that releases the lock and surfaces the error through the callback.

`connect()` now rejects promptly with the underlying error instead of hanging, and the lock is always released.

### 4. Don't hang when the bootstrap/seed host is unreachable on first connect

When `loadBalance` is enabled and the seed/bootstrap host is down on the very first connect (control client not yet established), `connect()`/`pool.connect()` never settled and hung forever.

`getConnection()` swallowed the control-connection error when the seed resolved to a single address and returned a never-connected control client. `getServersInfo()` then issued a query on that dead client: a request that never settled, so the user callback was never invoked and `connect()` hung.

We now:
- **`getConnection()`** throws the original error when the only resolved address is unreachable, instead of returning a never-connected control client.
- **`getServersInfo()`** rebuilds the control connection once and otherwise rejects, instead of swallowing the error (the previous fallback also referenced an out-of-scope `callback`).
- **`connect()` (control-client branch)** returns/awaits the `getServersInfo()` chain so `connect()` only settles after metadata is built and `nowConnect()` runs.
- **`nowConnect()` (callback path)** only re-enters `connect()` to retry when there is server metadata to pick another host; with no metadata (seed down on first connect) it surfaces the error instead of looping forever.

`connect()` now rejects promptly (well under a second when the seed refuses the connection) instead of hanging.

## Testing

Ran the node-postgres driver tests present in the driver-examples repo. Added a dedicated regression test (`yb-loadbalance-seed-down-connect.js`, in driver-examples) that creates a 3-node cluster, stops node 1, points the driver at node 1 as the seed, and asserts `client.connect()` (promise + callback) and `pool.connect()` all reject promptly instead of hanging. Verified the test fails (detects the hang) on the pre-fix driver and passes after.
