### PR TITLE
Increase mocha test timeout to 5s to handle CM DDL commit sleep

### DIFF
--- a/packages/pg-connection-string/package.json
+++ b/packages/pg-connection-string/package.json
@@ -5,7 +5,7 @@
   "main": "./index.js",
   "types": "./index.d.ts",
   "scripts": {
-    "test": "istanbul cover _mocha && npm run check-coverage",
+    "test": "istanbul cover _mocha -- --timeout 5000 && npm run check-coverage",
     "check-coverage": "istanbul check-coverage --statements 100 --branches 100 --lines 100 --functions 100",
     "coveralls": "cat ./coverage/lcov.info | ./node_modules/.bin/coveralls"
   },

--- a/packages/pg-cursor/test/mocha.opts
+++ b/packages/pg-cursor/test/mocha.opts
@@ -1,3 +1,4 @@
 --reporter spec
 --no-exit
 --bail
+--timeout 5000

--- a/packages/pg-pool/package.json
+++ b/packages/pg-pool/package.json
@@ -7,7 +7,7 @@
     "test": "test"
   },
   "scripts": {
-    "test": " node_modules/.bin/mocha"
+    "test": "node_modules/.bin/mocha --timeout 5000"
   },
   "repository": {
     "type": "git",

--- a/packages/pg-protocol/package.json
+++ b/packages/pg-protocol/package.json
@@ -16,7 +16,7 @@
     "typescript": "^4.0.3"
   },
   "scripts": {
-    "test": "mocha dist/**/*.test.js",
+    "test": "mocha --timeout 5000 dist/**/*.test.js",
     "build": "tsc",
     "build:watch": "tsc --watch",
     "prepublish": "yarn build",

--- a/packages/pg-query-stream/package.json
+++ b/packages/pg-query-stream/package.json
@@ -5,7 +5,7 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "scripts": {
-    "test": "mocha -r ts-node/register test/**/*.ts"
+    "test": "mocha -r ts-node/register --timeout 5000 test/**/*.ts"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
The tests were timing out because low test timeout for connection manager enabled cases. Increased the mocha package timeout to 5 seconds.